### PR TITLE
Realloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ other needs.
 
 ## Todo
 
-* `Rec` and underlying `Buf` need `realloc`
-* `Canvas` should implement resizing to smaller image with guaranteed reuse
 * `Canvas` mutation to differently sized types blocked by ..
 * .. `Rec` logical mutations, keeping `len` but not `byte_len`
 * Relaxing internal `Buf` requirements to allow reuse of memory for `f32` (only

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2019 The `image-rs` developers
 use core::mem;
-use core::ops::{Deref, DerefMut};
+use core::ops;
 
 use crate::pixels::{MaxAligned, MAX_ALIGN};
 use crate::Pixel;
@@ -160,7 +160,7 @@ fn prefix_slice<B, T>(slice: B) -> (B, B) where B: ByteSlice
     slice.split_at(len)
 }
 
-impl Deref for Buffer {
+impl ops::Deref for Buffer {
     type Target = buf;
 
     fn deref(&self) -> &buf {
@@ -168,9 +168,23 @@ impl Deref for Buffer {
     }
 }
 
-impl DerefMut for Buffer {
+impl ops::DerefMut for Buffer {
     fn deref_mut(&mut self) -> &mut buf {
         self.as_buf_mut()
+    }
+}
+
+impl ops::Index<ops::RangeTo<usize>> for buf {
+    type Output = buf;
+
+    fn index(&self, idx: ops::RangeTo<usize>) -> &buf {
+        Self::from_bytes(&self.0[idx]).unwrap()
+    }
+}
+
+impl ops::IndexMut<ops::RangeTo<usize>> for buf {
+    fn index_mut(&mut self, idx: ops::RangeTo<usize>) -> &mut buf {
+        Self::from_bytes_mut(&mut self.0[idx]).unwrap()
     }
 }
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,10 +1,11 @@
 // Distributed under The MIT License (MIT)
 //
 // Copyright (c) 2019 The `image-rs` developers
+use core::fmt;
 use core::ops::{Index, IndexMut};
 
 use zerocopy::{AsBytes, FromBytes};
-use crate::{AsPixel, Rec, Pixel};
+use crate::{AsPixel, Rec, ReuseError, Pixel};
 
 /// A 2d matrix of pixels.
 ///
@@ -71,16 +72,45 @@ pub struct Layout<P> {
     pixel: Pixel<P>,
 }
 
+/// Error representation for a failed buffer reuse for a canvas.
+///
+/// Emitted as a result of [`Canvas::from_rec`] when the buffer capacity is not large enough to
+/// serve as an image of requested layout with causing a reallocation.
+///
+/// It is possible to retrieve the buffer that cause the failure with `into_rec`. This allows one
+/// to manually try to correct the error with additional checks, or implement a fallback strategy
+/// which does not require the interpretation as a full image.
+///
+/// ```
+/// # use canvas::{Canvas, Rec, Layout};
+/// let rec = Rec::<u8>::new(16);
+/// let allocation = rec.as_bytes().as_ptr();
+///
+/// let bad_layout = Layout::width_and_height(rec.capacity() + 1, 1).unwrap();
+/// let error = match Canvas::reuse_rec(rec, bad_layout) {
+///     Ok(_) => unreachable!("The layout requires one too many pixels"),
+///     Err(error) => error,
+/// };
+///
+/// // Get back the original buffer.
+/// let rec = error.into_rec();
+/// assert_eq!(rec.as_bytes().as_ptr(), allocation);
+/// ```
+///
+/// [`Canvas::from_rec`]: ./struct.Canvas.html#from_rec
+pub struct CanvasReuseError<P: AsBytes + FromBytes> {
+    buffer: Rec<P>,
+    layout: Layout<P>,
+}
+
 impl<P: AsBytes + FromBytes> Canvas<P> {
     /// Allocate a canvas with specified layout.
     ///
     /// # Panics
     /// When allocation of memory fails.
     pub fn with_layout(layout: Layout<P>) -> Self {
-        Canvas {
-            inner: Rec::bytes_for_pixel(layout.pixel, layout.byte_len()),
-            layout,
-        }
+        let rec = Rec::bytes_for_pixel(layout.pixel, layout.byte_len());
+        Self::new_raw(rec, layout)
     }
 
     /// Directly try to allocate a canvas from width and height.
@@ -97,6 +127,46 @@ impl<P: AsBytes + FromBytes> Canvas<P> {
         Self::with_layout(layout)
     }
 
+    /// Interpret an existing buffer as an image.
+    ///
+    /// The data already contained within the buffer is not modified so that prior initialization
+    /// can be performed or one array of samples reinterpreted for an image of other sample type.
+    /// However, the `Rec` will be logically resized which will zero-initialize missing elements if
+    /// the current buffer is too short.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if resizing causes a reallocation that fails.
+    pub fn from_rec(mut buffer: Rec<P>, layout: Layout<P>) -> Self {
+        buffer.resize_bytes(layout.byte_len());
+        Self::new_raw(buffer, layout)
+    }
+
+    /// Reuse an existing buffer for an image.
+    ///
+    /// Similar to `from_rec` but this function will never reallocate the inner buffer. Instead, it
+    /// will return the `Rec` unmodified in the `Err` variant.
+    pub fn reuse_rec(mut buffer: Rec<P>, layout: Layout<P>)
+        -> Result<Self, CanvasReuseError<P>>
+    {
+        match buffer.reuse_bytes(layout.byte_len()) {
+            Ok(_) => (),
+            Err(_) => return Err(CanvasReuseError {
+                buffer,
+                layout,
+            }),
+        }
+        Ok(Self::new_raw(buffer, layout))
+    }
+
+    fn new_raw(inner: Rec<P>, layout: Layout<P>) -> Self {
+        assert_eq!(inner.len(), layout.len(), "Pixel count agrees with buffer");
+        Canvas {
+            inner,
+            layout,
+        }
+    }
+
     pub fn as_slice(&self) -> &[P] {
         &self.inner.as_slice()[..self.layout.len()]
     }
@@ -111,6 +181,22 @@ impl<P: AsBytes + FromBytes> Canvas<P> {
 
     pub fn as_bytes_mut(&mut self) -> &mut [u8] {
         &mut self.inner.as_bytes_mut()[..self.layout.byte_len()]
+    }
+
+    /// Resize the buffer for a new image.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if an allocation is necessary but fails.
+    pub fn resize(&mut self, layout: Layout<P>) {
+        self.inner.resize_bytes(layout.byte_len());
+        self.layout = layout;
+    }
+
+    /// Reuse the buffer for a new image layout.
+    pub fn reuse(&mut self, layout: Layout<P>) -> Result<(), ReuseError> {
+        self.inner.reuse_bytes(layout.byte_len())?;
+        Ok(self.layout = layout)
     }
 
     /// Reinterpret to another, same size pixel type.
@@ -134,6 +220,10 @@ impl<P: AsBytes + FromBytes> Canvas<P> {
             layout,
             inner,
         }
+    }
+
+    pub fn into_rec(self) -> Rec<P> {
+        self.inner
     }
 
     fn index_of(&self, x: usize, y: usize) -> usize {
@@ -217,6 +307,13 @@ impl<P> Layout<P> {
     }
 }
 
+impl<P: AsBytes + FromBytes> CanvasReuseError<P> {
+    /// Unwrap the original buffer.
+    pub fn into_rec(self) -> Rec<P> {
+        self.buffer
+    }
+}
+
 impl<P> Clone for Layout<P> { 
     fn clone(&self) -> Self {
         Layout {
@@ -249,5 +346,31 @@ impl<P: AsBytes + FromBytes> IndexMut<(usize, usize)> for Canvas<P> {
     fn index_mut(&mut self, (x, y): (usize, usize)) -> &mut P {
         let index = self.index_of(x, y);
         &mut self.as_mut_slice()[index]
+    }
+}
+
+impl<P: AsBytes + FromBytes> fmt::Debug for CanvasReuseError<P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Canvas requires {} elements but buffer has capacity for only {}",
+            self.layout.len(), self.buffer.capacity())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_reuse() {
+        let rec = Rec::<u8>::new(4);
+        assert!(rec.capacity() >= 4);
+        let layout = Layout::width_and_height(2, 2).unwrap();
+        let mut canvas = Canvas::reuse_rec(rec, layout)
+            .expect("Rec is surely large enough");
+        canvas.reuse(Layout::width_and_height(1, 1).unwrap())
+            .expect("Can scale down the image");
+        canvas.resize(Layout::width_and_height(0, 0).unwrap());
+        canvas.reuse(layout)
+            .expect("Can still reuse original allocation");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ use core::mem;
 
 use zerocopy::{AsBytes, FromBytes};
 
-pub use self::rec::Rec;
-pub use self::canvas::{Canvas, Layout};
+pub use self::rec::{Rec, ReuseError};
+pub use self::canvas::{Canvas, CanvasReuseError, Layout};
 
 /// Marker struct to denote a pixel type.
 ///

--- a/src/rec.rs
+++ b/src/rec.rs
@@ -27,9 +27,7 @@ impl<P: AsBytes + FromBytes> Rec<P> {
     /// Provides the opportunity to construct the pixel argument via other means than the trait,
     /// for example a dynamically checked expression.
     pub fn new_for_pixel(pixel: Pixel<P>, count: usize) -> Self {
-        let mem_size = pixel.size().checked_mul(count).unwrap_or_else(
-            || panic!("Requested count overflows memory size"));
-        Self::bytes_for_pixel(pixel, mem_size)
+        Self::bytes_for_pixel(pixel, mem_size(pixel, count))
     }
 
     /// Allocate a pixel buffer by providing the byte count you wish to allocate.
@@ -38,6 +36,46 @@ impl<P: AsBytes + FromBytes> Rec<P> {
             inner: Buffer::new(mem_size),
             pixel,
         }
+    }
+
+    /// Change the number of pixels.
+    ///
+    /// This will always reallocate the buffer if the size exceeds the current capacity.
+    pub fn resize(&mut self, count: usize) {
+        self.resize_bytes(mem_size(self.pixel, count))
+    }
+
+    /// Change the size in bytes.
+    ///
+    /// The length is afterwards equal to `bytes / mem::size_of::<P>()`, i.e. the quotient rounded
+    /// down.
+    ///
+    /// This will always reallocate the buffer if the size exceeds the current capacity.
+    pub fn resize_bytes(&mut self, bytes: usize) {
+        self.inner.resize(bytes)
+    }
+
+    /// Reallocate the slice to contain exactly as many bytes as necessary.
+    ///
+    /// The number of contained elements is not changed. However, the number of elements
+    /// interpreted as a different type may change.
+    ///
+    /// ```
+    /// # use canvas::Rec;
+    /// let rec_u8 = Rec::<u8>::new(7);
+    /// assert_eq!(rec_u8.len(), 7);
+    ///
+    /// let mut rec_u32 = rec_u8.reinterpret::<u32>();
+    /// assert_eq!(rec_u32.len(), 1);
+    /// rec_u32.shrink_to_fit();
+    ///
+    /// let rec_u8 = rec_u32.reinterpret::<u8>();
+    /// assert_eq!(rec_u8.len(), 4);
+    /// ```
+    pub fn shrink_to_fit(&mut self) {
+        let exact_size = mem_size(self.pixel, self.len());
+        self.resize_bytes(exact_size);
+        self.inner.shrink_to_fit();
     }
 
     pub fn as_slice(&self) -> &[P] {
@@ -51,6 +89,11 @@ impl<P: AsBytes + FromBytes> Rec<P> {
     /// The number of accessible elements for the current type.
     pub fn len(&self) -> usize {
         self.as_slice().len()
+    }
+
+    /// The number of elements that can fit without reallocation.
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity() / self.pixel.size()
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -67,6 +110,11 @@ impl<P: AsBytes + FromBytes> Rec<P> {
     /// capacity of the storage.
     pub fn byte_len(&self) -> usize {
         self.as_bytes().len()
+    }
+
+    /// The total number of managable bytes.
+    pub fn byte_capacity(&self) -> usize {
+        self.inner.capacity()
     }
 
     /// Reinterpret the buffer for a different type of pixel.
@@ -92,6 +140,11 @@ impl<P: AsBytes + FromBytes> Rec<P> {
             pixel,
         }
     }
+}
+
+fn mem_size<P>(pixel: Pixel<P>, count: usize) -> usize {
+    pixel.size().checked_mul(count).unwrap_or_else(
+        || panic!("Requested count overflows memory size"))
 }
 
 impl<P: AsBytes + FromBytes> Deref for Rec<P> {


### PR DESCRIPTION
Implements basic reallocation operations. Opening this as a pull request to solicit some feedback on missing operations I may have overlooked in the design.

- [x] Reallocation of `Rec`
- [x] Reallocation of `Canvas`