### PR TITLE
Upgrade required zerocopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - linux
     - osx
 rust:
+    - stable
     - nightly
 script:
     - cargo build -v && cargo test -v && cargo doc -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "image-canvas"
 description = "An allocated buffer suitable for image data."
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 edition = "2018"
 license = "MIT"
@@ -13,4 +13,4 @@ categories = ["multimedia::images"]
 name = "canvas"
 
 [dependencies]
-zerocopy = "0.2.3"
+zerocopy = "0.2.4"


### PR DESCRIPTION
That release removes the feature flag since that was recently
stabilized. This means that the crate builds on stable.

Closes: #1 