### PR TITLE
Update to 0.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "image-canvas"
 description = "An allocated buffer suitable for image data."
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
 edition = "2018"
 license = "MIT"

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,8 @@
-## v0.0.5
+## v0.0.6
 
 * Add mapping operations over pixels of a buffer or canvas
+* Fix a bug that caused reallocations to be too short
+
+## v0.0.5
+
 * Update `zerocopy` to a version supporting `f32`


### PR DESCRIPTION
Also fixes a bug in the patch notes. The `map` operation was not published in the previous version.