### PR TITLE
Switch to bytemuck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["multimedia::images"]
 name = "canvas"
 
 [dependencies]
-zerocopy = "0.2.8"
+bytemuck = "1.1"

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -5,8 +5,6 @@ use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use core::marker::PhantomData;
 use core::{fmt, mem};
 
-use zerocopy::{AsBytes, FromBytes};
-
 /// Marker struct to denote a pixel type.
 ///
 /// Can be constructed only for types that have expected alignment and no byte invariants. It
@@ -28,10 +26,13 @@ pub(crate) const MAX_ALIGN: usize = 16;
 /// A byte-like-type that is aligned to the required max alignment.
 ///
 /// This type does not contain padding and implements `FromBytes`.
-#[derive(Clone, Copy, AsBytes, FromBytes)]
+#[derive(Clone, Copy)]
 #[repr(align(16))]
 #[repr(C)]
 pub struct MaxAligned(pub(crate) [u8; 16]);
+
+unsafe impl bytemuck::Zeroable for MaxAligned { }
+unsafe impl bytemuck::Pod for MaxAligned { }
 
 pub(crate) mod constants {
     use super::{AsPixel, MaxAligned, Pixel};
@@ -65,7 +66,7 @@ pub(crate) mod constants {
     );
 }
 
-impl<P: AsBytes + FromBytes> Pixel<P> {
+impl<P: bytemuck::Pod> Pixel<P> {
     /// Try to construct an instance of the marker.
     ///
     /// If successful, you can freely use it to access the image buffers.


### PR DESCRIPTION
Pros:
The crate is more minimal
The source code comes with a public bug tracker
The crate has a useful stable version
The minimum Rust version is 1.34

Cons:
We lose the distinction of AsBytes and FromBytes. But firstly, this
might be temporary. Depending on how bytemuck will procede there might
be a chance to get this back. Secondly, this has not really proven
useful. The only real chance to use it would have been to somehow
allocate the data yourself which had not been supported.

All pixel types are required to be Copy. That's probably good as no
longer is there any unexpected not-occurring Drop. The bytemuck crate
seems more reasonable here.