### PR TITLE
Annotate the crate with no_std and alloc

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -4,6 +4,8 @@
 use core::mem;
 use core::ops;
 
+use alloc::vec::Vec;
+
 use crate::pixel::{MaxAligned, Pixel, MAX_ALIGN};
 use bytemuck::{cast_slice, cast_slice_mut, Pod};
 
@@ -47,7 +49,7 @@ impl Buffer {
     /// Panics if the length is too long to find a properly aligned subregion.
     pub fn new(length: usize) -> Self {
         let alloc_len = Self::alloc_len(length);
-        let inner = vec![Self::ELEMENT; alloc_len];
+        let inner = alloc::vec![Self::ELEMENT; alloc_len];
 
         Buffer { inner }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,10 @@
 //! // Send the raw bytes
 //! send_over_network(encoded.as_bytes());
 //! ```
+// Be std for doctests, avoids a weird warning about missing allocator.
+#![cfg_attr(not(doctest), no_std)]
+extern crate alloc;
+
 mod buf;
 mod canvas;
 mod pixel;


### PR DESCRIPTION
The really important part of the switch is that we do not perform any
IO. Note that even the arch-specific types for SIMD would be available
in the core crate if we ever want to use them.