### PR TITLE
Untyped canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ other needs.
 
 ## Todo
 
-* `Canvas` mutation to differently sized types blocked by ..
+* `Matrix` mutation to differently sized types blocked by ..
 * .. `Rec` logical mutations, keeping `len` but not `byte_len`
 * Relaxing internal `Buf` requirements to allow reuse of memory for `f32` (only
   `AsBytes` but not `FromBytes`)

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ other needs.
 
 ## Todo
 
-* `Matrix` mutation to differently sized types blocked by ..
-* .. `Rec` logical mutations, keeping `len` but not `byte_len`
-* Relaxing internal `Buf` requirements to allow reuse of memory for `f32` (only
-  `AsBytes` but not `FromBytes`)
 * Use alignment for SIMD iteration/transmutation/map-operation
 * Ensure `core::mem::needs_drop` is `false` to provide better semantics for values.
 

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -455,6 +455,18 @@ impl From<&'_ buf> for Buffer {
     }
 }
 
+impl Default for &'_ buf {
+    fn default() -> Self {
+        buf::new(&mut [])
+    }
+}
+
+impl Default for &'_ mut buf {
+    fn default() -> Self {
+        buf::new_mut(&mut [])
+    }
+}
+
 impl borrow::Borrow<buf> for Buffer {
     fn borrow(&self) -> &buf {
         &**self

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -524,6 +524,18 @@ impl ops::DerefMut for Cog<'_> {
     }
 }
 
+impl borrow::Borrow<buf> for Cog<'_> {
+    fn borrow(&self) -> &buf {
+        &**self
+    }
+}
+
+impl borrow::BorrowMut<buf> for Cog<'_> {
+    fn borrow_mut(&mut self) -> &mut buf {
+        &mut **self
+    }
+}
+
 impl cmp::PartialEq<Cog<'_>> for Cog<'_> {
     fn eq(&self, other: &Cog<'_>) -> bool {
         **self == **other
@@ -539,6 +551,14 @@ impl cmp::PartialEq for buf {
 }
 
 impl cmp::Eq for buf {}
+
+impl cmp::PartialEq for Buffer {
+    fn eq(&self, other: &Buffer) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+
+impl cmp::Eq for Buffer {}
 
 impl ops::Index<ops::RangeTo<usize>> for buf {
     type Output = buf;

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,8 +1,7 @@
 // Distributed under The MIT License (MIT)
 //
 // Copyright (c) 2019 The `image-rs` developers
-use core::mem;
-use core::ops;
+use core::{borrow, mem, ops};
 
 use alloc::vec::Vec;
 
@@ -404,6 +403,27 @@ impl<'a> ByteSlice for &'a mut [u8] {
 
     fn split_at(self, at: usize) -> (Self, Self) {
         self.split_at_mut(at)
+    }
+}
+
+impl borrow::Borrow<buf> for Buffer {
+    fn borrow(&self) -> &buf {
+        &**self
+    }
+}
+
+impl borrow::BorrowMut<buf> for Buffer {
+    fn borrow_mut(&mut self) -> &mut buf {
+        &mut **self
+    }
+}
+
+impl alloc::borrow::ToOwned for buf {
+    type Owned = Buffer;
+    fn to_owned(&self) -> Buffer {
+        let mut buffer = Buffer::new(self.len());
+        buffer.as_bytes_mut().copy_from_slice(self);
+        buffer
     }
 }
 

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -115,7 +115,7 @@ impl Cog<'_> {
         }
     }
 
-    fn grow_to(this: &mut Self, bytes: usize) -> &mut buf {
+    pub(crate) fn grow_to(this: &mut Self, bytes: usize) -> &mut buf {
         if this.len() < bytes {
             Cog::to_owned(this).grow_to(bytes);
         }
@@ -438,6 +438,20 @@ impl<'a> ByteSlice for &'a mut [u8] {
 
     fn split_at(self, at: usize) -> (Self, Self) {
         self.split_at_mut(at)
+    }
+}
+
+impl From<&'_ [u8]> for Buffer {
+    fn from(content: &'_ [u8]) -> Self {
+        let mut buffer = Buffer::new(content.len());
+        buffer[..content.len()].copy_from_slice(content);
+        buffer
+    }
+}
+
+impl From<&'_ buf> for Buffer {
+    fn from(content: &'_ buf) -> Self {
+        content.to_owned()
     }
 }
 

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,7 +1,7 @@
 // Distributed under The MIT License (MIT)
 //
 // Copyright (c) 2019 The `image-rs` developers
-use core::{borrow, mem, ops};
+use core::{borrow, cmp, mem, ops};
 
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
@@ -523,6 +523,22 @@ impl ops::DerefMut for Cog<'_> {
         }
     }
 }
+
+impl cmp::PartialEq<Cog<'_>> for Cog<'_> {
+    fn eq(&self, other: &Cog<'_>) -> bool {
+        **self == **other
+    }
+}
+
+impl cmp::Eq for Cog<'_> {}
+
+impl cmp::PartialEq for buf {
+    fn eq(&self, other: &buf) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+
+impl cmp::Eq for buf {}
 
 impl ops::Index<ops::RangeTo<usize>> for buf {
     type Output = buf;

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -3,48 +3,62 @@
 // Copyright (c) 2019, 2020 The `image-rs` developers
 use bytemuck::Pod;
 
+use crate::Rec;
 use crate::buf::{Buffer, Cog};
 use crate::layout::{DynLayout, Layout, SampleSlice};
 
 /// A canvas, parameterized over the layout.
 ///
+/// The buffer is either owned or _mutably_ borrowed from another `Canvas`. Some allocating methods
+/// may lead to an implicit change from a borrowed to an owned buffer. These methods are documented
+/// as performing a fallible allocation. Other method calls on the previously borrowing canvas will
+/// afterwards no longer change the bytes of the canvas it was borrowed from.
+/// 
+/// This type permits user defined layouts of any kind and does not unsafely depend on the validity
+/// of the layouts. Correctness is achieved in the common case by discouraging methods that would
+/// lead to a diverging size of the memory buffer and the layout. Hence, access to the image pixels
+/// should not lead to panic unless an incorrectly implemented layout is used.
+///
+/// Since a `Canvas` can not unsafely rely on the layout behaving correctly, direct accessors may
+/// have suboptimal behaviour and perform a few (seemingly) redundant checks. More optimal, but
+/// much more specialized, wrappers are provided in other types such as `Matrix`.
+///
+/// Note also that the borrowing canvas can arbitrarily change its own layout and thus overwrite
+/// the content with completely different types and layouts. This is intended to maximize the
+/// flexibility for users. In complicated cases it could be hard for the type system to reflect the
+/// compatibility of a custom pixel layout and a standard one. It is solely the user's
+/// responsibility to use the interface sensibly. The _soundness_ of standard channel types (e.g.
+/// `u8` or `u32`) is not impacted by this as any byte content is valid for them.
+///
 /// It is possible to convert the layout to a less strictly typed one without reallocating the
 /// buffer. For example, all standard layouts such as `Matrix` can be weakened to `DynLayout`. The
 /// reverse can not be done unchecked but is possible with fallible conversions.
 ///
-/// A `Canvas` allows can not unsafely rely on the layout behaving correctly. Hence, direct
-/// accessors may have suboptimal behaviour and perform a few (seemingly) redundant checks. More
-/// optimal, but much more specialized, wrappers are provided in other types such as `Matrix`.
+/// ## Examples
 ///
 /// ```
 /// ```
-pub struct Canvas<'buf, Layout = DynLayout> {
+pub struct Canvas<'buf, Layout> {
     buffer: Cog<'buf>,
     layout: Layout,
 }
 
-/// Layout oblivious methods.
+/// Layout oblivious methods that can allocate and change to another buffer.
 impl<'buf, L> Canvas<'buf, L> {
-    /// Get a reference to the unstructured bytes of the canvas.
-    pub fn as_bytes(&self) -> &[u8] {
-        self.buffer.as_bytes()
-    }
-
-    /// Get a mutable reference to the unstructured bytes of the canvas.
-    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
-        self.buffer.as_bytes_mut()
-    }
-
-    /// Get a reference to the layout.
-    pub fn layout(&self) -> &L {
-        &self.layout
+    /// Grow the buffer, preparing for another layout.
+    ///
+    /// This may allocate a new buffer and thus disassociate the image from the currently borrowed
+    /// underlying buffer.
+    ///
+    /// # Panics
+    /// This function will panic if an allocation is necessary but fails.
+    pub fn grow(&mut self, layout: &impl Layout) {
+        Cog::grow_to(&mut self.buffer, layout.byte_len());
     }
 
     /// Convert the inner layout.
     ///
-    /// This method expects that the converted layout is compatible with the current layout. Note
-    /// that this permits user defined layouts of any kind and does not unsafely depend on the
-    /// validity of the conversion.
+    /// This method expects that the converted layout is compatible with the current layout.
     ///
     /// # Panics
     /// This method panics if the new layout requires more bytes and allocation fails.
@@ -61,17 +75,149 @@ impl<'buf, L> Canvas<'buf, L> {
         }
     }
 
-    pub fn into_dynamic(self) -> Canvas<'buf>
+    /// Convert the inner layout to a dynamic one.
+    ///
+    /// This is mostly convenience. Also not that `DynLayout` is of course not _completely_ generic
+    /// but tries to emulate a large number of known layouts.
+    ///
+    /// # Panics
+    /// This method panics if the new layout requires more bytes and allocation fails.
+    pub fn into_dynamic(self) -> Canvas<'buf, DynLayout>
     where
         L: Into<DynLayout>,
     {
         self.into_layout()
     }
 
+    /// Change the layout, reusing and growing the buffer.
+    ///
+    /// # Panics
+    /// This method panics if the new layout requires more bytes and allocation fails.
+    pub fn into_reinterpreted<Other: Layout>(mut self, layout: Other)
+        -> Canvas<'buf, Other>
+    {
+        Cog::grow_to(&mut self.buffer, layout.byte_len());
+        Canvas {
+            buffer: self.buffer,
+            layout,
+        }
+    }
+
+    /// Mutably borrow this canvas with another arbitrary layout.
+    ///
+    /// The other layout could be completely incompatible and perform arbitrary mutations. This
+    /// seems counter intuitive at first, but recall that these mutations are not unsound as they
+    /// can not invalidate the bytes themselves and only write unexpected values. This provides
+    /// more flexibility for 'transmutes' than easily expressible in the type system.
+    ///
+    /// # Panics
+    /// This method panics if the new layout requires more bytes and allocation fails.
+    pub fn as_reinterpreted<Other>(&mut self, other: Other)
+        -> Canvas<'_, Other>
+    where
+        Other: Layout,
+    {
+        self.grow(&other);
+        Canvas {
+            buffer: Cog::Borrowed(&mut self.buffer),
+            layout: other,
+        }
+    }
+
+    /// Take ownership of the image's bytes.
+    ///
+    /// # Panics
+    /// This method panics if allocation fails.
     pub fn into_owned(self) -> Canvas<'static, L> {
         Canvas {
             buffer: Cog::Owned(Cog::into_owned(self.buffer)),
             layout: self.layout,
+        }
+    }
+}
+
+/// Layout oblivious methods, these also never allocate or panic.
+impl<'buf, L> Canvas<'buf, L> {
+    /// Get a reference to the unstructured bytes of the canvas.
+    ///
+    /// Note that this may return more bytes than required for the specific layout for various
+    /// reasons. See also [`as_layout_bytes`].
+    ///
+    /// [`as_layout_bytes`]: #method.as_layout_bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        self.buffer.as_bytes()
+    }
+
+    /// Get a mutable reference to the unstructured bytes of the canvas.
+    ///
+    /// Note that this may return more bytes than required for the specific layout for various
+    /// reasons. See also [`as_layout_bytes_mut`].
+    ///
+    /// [`as_layout_bytes_mut`]: #method.as_layout_bytes_mut
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        self.buffer.as_bytes_mut()
+    }
+
+    /// Get a reference to the layout.
+    pub fn layout(&self) -> &L {
+        &self.layout
+    }
+
+    /// Reinterpret the bits in another layout.
+    ///
+    /// This method fails if the layout requires more bytes than are currently allocated.
+    pub fn try_reinterpret<Other>(self, layout: Other)
+        -> Result<Canvas<'buf, Other>, Self>
+    where
+        Other: Layout,
+    {
+        if self.buffer.len() > layout.byte_len() {
+            Err(self)
+        } else {
+            Ok(Canvas {
+                buffer: self.buffer,
+                layout,
+            })
+        }
+    }
+
+    /// Change the layout without checking the buffer.
+    pub fn reinterpret_unguarded<Other: Layout>(self, layout: Other)
+        -> Canvas<'buf, Other>
+    {
+        Canvas {
+            buffer: self.buffer,
+            layout,
+        }
+    }
+
+    /// Borrow the buffer with the same layout.
+    pub fn borrow_mut(&mut self) -> Canvas<'_, L>
+    where
+        L: Clone,
+    {
+        Canvas {
+            buffer: Cog::Borrowed(&mut self.buffer),
+            layout: self.layout.clone(),
+        }
+    }
+}
+
+/// Methods specifically with a dynamic layout.
+impl<'buf> Canvas<'buf, DynLayout> {
+    pub fn try_from_dynamic<Other>(self, layout: Other)
+        -> Result<Canvas<'buf, Other>, Self>
+    where
+        Other: Into<DynLayout> + Clone,
+    {
+        let reference = layout.clone().into();
+        if self.layout == reference {
+            Ok(Canvas {
+                buffer: self.buffer,
+                layout,
+            })
+        } else {
+            Err(self)
         }
     }
 }
@@ -87,6 +233,17 @@ impl<'buf, L: Layout> Canvas<'buf, L> {
         }
     }
 
+    /// Get a reference to those bytes used by the layout.
+    pub fn as_layout_bytes(&self) -> &[u8] {
+        &self.as_bytes()[..self.layout.byte_len()]
+    }
+
+    /// Get a mutable reference to those bytes used by the layout.
+    pub fn as_layout_bytes_mut(&mut self) -> &mut [u8] {
+        let len = self.layout.byte_len();
+        &mut self.as_bytes_mut()[..len]
+    }
+
     /// Create a canvas from a byte slice specifying the contents.
     ///
     /// If the layout requires more bytes then the remaining bytes are zero initialized.
@@ -98,26 +255,6 @@ impl<'buf, L: Layout> Canvas<'buf, L> {
             layout,
         }
     }
-
-    /// Mutably borrow this canvas with another layout.
-    ///
-    /// The other layout could be completely incompatible and perform arbitrary mutations. This
-    /// seems counter intuitive at first, but recall that these mutations are not unsound as they
-    /// can not invalidate the bytes themselves and only write unexpected values. This provides
-    /// more flexibility for 'transmutes' than easily expressible in the type system.
-    ///
-    /// # Panics
-    /// This method panic if the other layout requires more bytes than allocated for this layout.
-    pub fn as_layout<Other>(&mut self, other: Other) -> Canvas<'_, Other>
-    where
-        Other: Layout,
-    {
-        assert!(other.byte_len() <= self.buffer.len());
-        Canvas {
-            buffer: Cog::Borrowed(&mut self.buffer),
-            layout: other,
-        }
-    }
 }
 
 /// Methods for layouts that are slices of individual samples.
@@ -125,8 +262,31 @@ impl<'buf, L: SampleSlice> Canvas<'buf, L>
 where
     L::Sample: Pod,
 {
+    /// Interpret an existing buffer as a pixel canvas.
+    ///
+    /// The data already contained within the buffer is not modified so that prior initialization
+    /// can be performed or one array of samples reinterpreted for an image of other sample type.
+    /// However, the `Rec` will be logically resized which will zero-initialize missing elements if
+    /// the current buffer is too short.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if resizing causes a reallocation that fails.
+    pub fn from_rec(buffer: Rec<L::Sample>, layout: L) -> Self {
+        let mut buffer = buffer.into_inner();
+        buffer.grow_to(layout.byte_len());
+        Self {
+            buffer: Cog::Owned(buffer),
+            layout,
+        }
+    }
+
     pub fn as_slice(&self) -> &[L::Sample] {
-        self.buffer.as_pixels(L::sample())
+        self.buffer.as_pixels(self.layout.sample())
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [L::Sample] {
+        self.buffer.as_mut_pixels(self.layout.sample())
     }
 }
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -32,16 +32,15 @@ use crate::{Rec, ReuseError};
 /// reverse can not be done unchecked but is possible with fallible conversions.
 ///
 /// Note also that `Canvas` provides fallible operations, some of them are meant to modify the
-/// type. This can obviously not be performed in-place as it would be common if the type did not
-/// change. Instead we approximate at least the result type by taking the buffer on success and
-/// leaving it unchanged in case of failure. A example signature for this is:
+/// type. This can obviously not be performed in-place, in the manner with which it would be common
+/// if the type did not change. Instead we approximate at least the result type by transferring the
+/// buffer on success while leaving it unchanged in case of failure. An example signature for this is:
 ///
 /// > [`fn mend<M>(&mut self, with: L::Item) -> Option<Canvas<M>>`][`mend`]
 ///
 /// [`mend`]: #method.mend
 ///
 /// ## Examples
-/// TODO
 ///
 /// ```
 /// ```

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,21 +1,132 @@
 // Distributed under The MIT License (MIT)
 //
 // Copyright (c) 2019, 2020 The `image-rs` developers
-use crate::buf::{Buffer, Cog};
-use crate::layout::{Element, Matrix};
+use bytemuck::Pod;
 
-pub struct Canvas<'buf, Layout> {
+use crate::buf::{Buffer, Cog};
+use crate::layout::{DynLayout, Layout, SampleSlice};
+
+/// A canvas, parameterized over the layout.
+///
+/// It is possible to convert the layout to a less strictly typed one without reallocating the
+/// buffer. For example, all standard layouts such as `Matrix` can be weakened to `DynLayout`. The
+/// reverse can not be done unchecked but is possible with fallible conversions.
+///
+/// A `Canvas` allows can not unsafely rely on the layout behaving correctly. Hence, direct
+/// accessors may have suboptimal behaviour and perform a few (seemingly) redundant checks. More
+/// optimal, but much more specialized, wrappers are provided in other types such as `Matrix`.
+///
+/// ```
+/// ```
+pub struct Canvas<'buf, Layout = DynLayout> {
     buffer: Cog<'buf>,
     layout: Layout,
 }
 
-impl<'buf, Layout> Canvas<'buf, Layout> {
+/// Layout oblivious methods.
+impl<'buf, L> Canvas<'buf, L> {
+    /// Get a reference to the unstructured bytes of the canvas.
     pub fn as_bytes(&self) -> &[u8] {
         self.buffer.as_bytes()
     }
 
+    /// Get a mutable reference to the unstructured bytes of the canvas.
     pub fn as_bytes_mut(&mut self) -> &mut [u8] {
         self.buffer.as_bytes_mut()
+    }
+
+    /// Get a reference to the layout.
+    pub fn layout(&self) -> &L {
+        &self.layout
+    }
+
+    /// Convert the inner layout.
+    ///
+    /// This method expects that the converted layout is compatible with the current layout. Note
+    /// that this permits user defined layouts of any kind and does not unsafely depend on the
+    /// validity of the conversion.
+    ///
+    /// # Panics
+    /// This method panics if the new layout requires more bytes and allocation fails.
+    pub fn into_layout<Other>(mut self) -> Canvas<'buf, Other>
+    where
+        L: Into<Other>,
+        Other: Layout,
+    {
+        let layout = self.layout.into();
+        Cog::grow_to(&mut self.buffer, layout.byte_len());
+        Canvas {
+            buffer: self.buffer,
+            layout,
+        }
+    }
+
+    pub fn into_dynamic(self) -> Canvas<'buf>
+    where
+        L: Into<DynLayout>,
+    {
+        self.into_layout()
+    }
+
+    pub fn into_owned(self) -> Canvas<'static, L> {
+        Canvas {
+            buffer: Cog::Owned(Cog::into_owned(self.buffer)),
+            layout: self.layout,
+        }
+    }
+}
+
+/// Methods for all `Layouts` (the trait).
+impl<'buf, L: Layout> Canvas<'buf, L> {
+    /// Allocate a buffer for a particular layout.
+    pub fn new(layout: L) -> Self {
+        let bytes = layout.byte_len();
+        Canvas {
+            buffer: Cog::Owned(Buffer::new(bytes)),
+            layout,
+        }
+    }
+
+    /// Create a canvas from a byte slice specifying the contents.
+    ///
+    /// If the layout requires more bytes then the remaining bytes are zero initialized.
+    pub fn with_contents(buffer: &[u8], layout: L) -> Self {
+        let mut buffer = Buffer::from(buffer);
+        buffer.grow_to(layout.byte_len());
+        Canvas {
+            buffer: Cog::Owned(buffer),
+            layout,
+        }
+    }
+
+    /// Mutably borrow this canvas with another layout.
+    ///
+    /// The other layout could be completely incompatible and perform arbitrary mutations. This
+    /// seems counter intuitive at first, but recall that these mutations are not unsound as they
+    /// can not invalidate the bytes themselves and only write unexpected values. This provides
+    /// more flexibility for 'transmutes' than easily expressible in the type system.
+    ///
+    /// # Panics
+    /// This method panic if the other layout requires more bytes than allocated for this layout.
+    pub fn as_layout<Other>(&mut self, other: Other) -> Canvas<'_, Other>
+    where
+        Other: Layout,
+    {
+        assert!(other.byte_len() <= self.buffer.len());
+        Canvas {
+            buffer: Cog::Borrowed(&mut self.buffer),
+            layout: other,
+        }
+    }
+}
+
+/// Methods for layouts that are slices of individual samples.
+impl<'buf, L: SampleSlice> Canvas<'buf, L>
+where
+    L::Sample: Pod,
+{
+    pub fn as_slice(&self) -> &[L::Sample] {
+        self.buffer.as_pixels(L::sample())
     }
 }
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -6,7 +6,7 @@ use core::{fmt, ops};
 use bytemuck::Pod;
 
 use crate::buf::{buf, Buffer, Cog};
-use crate::layout::{Bytes, Decay, DynLayout, Layout, Mend, SampleSlice, Take};
+use crate::layout::{Bytes, Coord, Decay, DynLayout, Layout, Mend, SampleSlice, Take};
 use crate::{Rec, ReuseError};
 
 /// A owned canvas, parameterized over the layout.
@@ -58,6 +58,29 @@ pub struct Canvas<Layout = Bytes> {
 #[derive(Clone, PartialEq, Eq)]
 pub struct CopyOnGrow<'buf, Layout = Bytes> {
     inner: RawCanvas<Cog<'buf>, Layout>,
+}
+
+/// A read-only view of a canvas.
+#[derive(Clone, PartialEq, Eq)]
+pub struct View<'buf, Layout = Bytes> {
+    inner: RawCanvas<&'buf buf, Layout>,
+}
+
+/// A writeable reference to a canvas.
+#[derive(PartialEq, Eq)]
+pub struct ViewMut<'buf, Layout = Bytes> {
+    inner: RawCanvas<&'buf mut buf, Layout>,
+}
+
+/// A raster layout.
+pub trait Raster<Pixel>: Sized {
+    fn dimensions(&self) -> Coord;
+    fn get(from: View<Self>, at: Coord) -> Pixel;
+}
+
+/// A raster layout where one can change pixel values independently.
+pub trait RasterMut<Pixel>: Raster<Pixel> {
+    fn put(into: ViewMut<Self>, at: Coord, val: Pixel);
 }
 
 /// Inner buffer implementation.

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -6,7 +6,7 @@ use core::{fmt, ops};
 use bytemuck::Pod;
 
 use crate::buf::{buf, Buffer, Cog};
-use crate::layout::{DynLayout, Layout, SampleSlice};
+use crate::layout::{Bytes, DynLayout, Layout, SampleSlice};
 use crate::{Rec, ReuseError};
 
 /// A owned canvas, parameterized over the layout.
@@ -36,7 +36,7 @@ use crate::{Rec, ReuseError};
 /// ```
 /// ```
 #[derive(Clone, PartialEq, Eq)]
-pub struct Canvas<Layout> {
+pub struct Canvas<Layout = Bytes> {
     inner: RawCanvas<Buffer, Layout>,
 }
 
@@ -47,7 +47,7 @@ pub struct Canvas<Layout> {
 /// as performing a fallible allocation. Other method calls on the previously borrowing canvas will
 /// afterwards no longer change the bytes of the canvas it was borrowed from.
 #[derive(Clone, PartialEq, Eq)]
-pub struct CopyOnGrow<'buf, Layout> {
+pub struct CopyOnGrow<'buf, Layout = Bytes> {
     inner: RawCanvas<Cog<'buf>, Layout>,
 }
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -32,6 +32,7 @@ use crate::{Rec, ReuseError};
 /// reverse can not be done unchecked but is possible with fallible conversions.
 ///
 /// ## Examples
+/// TODO
 ///
 /// ```
 /// ```
@@ -93,7 +94,7 @@ impl<L: Layout> Canvas<L> {
     /// See the [`Decay`] trait for an explanation of this operation.
     pub fn decay<M>(self) -> Canvas<M>
     where
-        L: Decay<M>,
+        M: Decay<L>,
         M: Layout,
     {
         self.inner.decay().into()
@@ -197,10 +198,9 @@ impl<B: Growable, L> RawCanvas<B, L> {
     /// This method panics if the new layout requires more bytes and allocation fails.
     pub(crate) fn decay<Other>(mut self) -> RawCanvas<B, Other>
     where
-        L: Decay<Other>,
-        Other: Layout,
+        Other: Decay<L>,
     {
-        let layout = self.layout.decay();
+        let layout = Other::decay(self.layout);
         Growable::grow_to(&mut self.buffer, layout.byte_len());
         RawCanvas {
             buffer: self.buffer,
@@ -217,7 +217,7 @@ impl<B: Growable, L> RawCanvas<B, L> {
     /// This method panics if the new layout requires more bytes and allocation fails.
     pub(crate) fn into_dynamic(self) -> RawCanvas<B, DynLayout>
     where
-        L: Decay<DynLayout>,
+        DynLayout: Decay<L>,
     {
         self.decay()
     }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,0 +1,29 @@
+// Distributed under The MIT License (MIT)
+//
+// Copyright (c) 2019, 2020 The `image-rs` developers
+use crate::buf::{Buffer, Cog};
+use crate::layout::{Element, Matrix};
+
+pub struct Canvas<'buf, Layout> {
+    buffer: Cog<'buf>,
+    layout: Layout,
+}
+
+impl<'buf, Layout> Canvas<'buf, Layout> {
+    pub fn as_bytes(&self) -> &[u8] {
+        self.buffer.as_bytes()
+    }
+
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        self.buffer.as_bytes_mut()
+    }
+}
+
+impl<Layout: Default> Default for Canvas<'_, Layout> {
+    fn default() -> Self {
+        Canvas {
+            buffer: Cog::Owned(Buffer::default()),
+            layout: Layout::default(),
+        }
+    }
+}

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -143,12 +143,12 @@ impl<L: Layout> Canvas<L> {
     /// buffer is kept by this canvas.
     ///
     /// [`Mend`]: ../layout/trait.Mend.html
-    pub fn mend<M>(&mut self, with: L::Item) -> Option<Canvas<M>>
+    pub fn mend<Item>(&mut self, mend: Item) -> Option<Canvas<Item::Into>>
     where
-        L: Mend<M> + Take,
-        M: Layout,
+        Item: Mend<L>,
+        L: Take,
     {
-        let new_layout = self.inner.layout().mend(with)?;
+        let new_layout = mend.mend(self.inner.layout())?;
         Some(self.inner.take().reinterpret_unguarded(new_layout).into())
     }
 }

--- a/src/drm.rs
+++ b/src/drm.rs
@@ -1,0 +1,126 @@
+use crate::layout::DynLayout;
+
+/// A direct rendering manager format info.
+///
+/// This structure is a cleaned-up version of the one present in the Linux kernel rendering
+/// subsystem, with deprecated fields removed. It is not a `Layout` itself since it is not
+/// guaranteed to be internally consistent, it does not yet describe width and height or it might
+/// otherwise not be supported. Try to convert it to a `DynLayout`.
+///
+/// See: the Linux kernel header `drm/drm_fourcc.h`.
+#[derive(Clone, Copy, Debug, Hash)]
+pub struct DrmFormatInfo {
+    /// The 4CC format identifier.
+    pub format: FourCC,
+    /// The number of image color planes (1 to 3).
+    pub num_planes: u8,
+    /// The number of bytes per block.
+    pub char_per_block: [u8; 4],
+    /// The width of a block in pixels.
+    pub block_w: [u8; 4],
+    /// The height of a block in pixels.
+    pub block_h: [u8; 4],
+    /// The horizontal chroma subsampling factor.
+    pub hsub: u8,
+    /// The vertical chroma subsampling factor.
+    pub vsub: u8,
+    /// Does the format embed an alpha component?
+    pub has_alpha: bool,
+    /// Is it a YUV format?
+    pub is_yuv: bool,
+}
+
+/// A descriptor for a single frame buffer.
+///
+/// In Linux, used to request new buffers or reallocation of buffers.
+///
+/// See: the Linux kernel header `drm/drm_mode.h`.
+#[derive(Clone, Copy, Debug, Hash)]
+pub struct DrmFramebufferCmd {
+    pub width: u32,
+    pub height: u32,
+    pub fourcc: FourCC,
+    pub flags: i32,
+    pub pitches: [u32; 4],
+    pub offsets: [u32; 4],
+    pub modifier: [u64; 4],
+}
+
+/// The filled-in info about a frame buffer.
+pub(crate) struct DrmFramebuffer {
+    pub format: DrmFormatInfo,
+    pub pitches: [u32; 4],
+    pub offsets: [u32; 4],
+    pub modifier: u64,
+    pub width: u32,
+    pub height: u32,
+    pub flags: i32,
+}
+
+/// A direct rendering manager format info that is supported as a layout.
+pub struct DrmLayout {
+    pub(crate) info: DrmFramebuffer,
+}
+
+/// An error converting an info into a supported layout.
+pub struct BadDrmError {
+    _private: (),
+}
+
+/// A 4CC format identifier.
+///
+/// This exist to define the common formats as constants and to typify the conversion and
+/// representation of values involved. The code is always stored as little endian.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FourCC(u32);
+
+impl DrmFormatInfo {
+    /// Create a layout with particular dimensions.
+    ///
+    /// This is a partial function to represent that not all descriptors can be convert to a
+    /// possible dynamic layouts. No successful conversion will get removed across SemVer
+    /// compatible versions.
+    pub fn into_layout(self, _: u32, _: u32) -> Option<DynLayout> {
+        None
+    }
+}
+
+impl DrmLayout {
+    pub fn new(info: &DrmFramebufferCmd) -> Result<Self, BadDrmError> {
+        let info = info.fourcc.info()?;
+        Err(BadDrmError { _private: () })
+    }
+}
+
+impl FourCC {
+    /* Relevant formats according to Linux header `uapi/drm/drm_fourcc.h` */
+    /// The constant denoting an invalid format, e.g. signalling a missing format.
+    pub const INVALID: Self = FourCC(0);
+    /// Single 8 bpp grey color.
+    pub const C8: Self = FourCC::from(*b"C8  ");
+
+    /* 8 bpp rgb */
+    /// 8bpp rgb with 3 bits red, 3 bits green, 2 bits blue.
+    pub const RGB332: Self = FourCC::from(*b"RGB8");
+    /// 8bpp rgb with 2 bits red, 3 bits green, 3 bits blue.
+    pub const BGR332: Self = FourCC::from(*b"BGR8");
+
+    /* 16 bpp rgb */
+    /// 16 bpp xrgb with 4 bits each.
+    pub const XRGB444: Self = FourCC::from(*b"XR12");
+    /// 16 bpp xbgr with 4 bits each.
+    pub const XBRG444: Self = FourCC::from(*b"XB12");
+    /// 16 bpp rgbx with 4 bits each.
+    pub const RGBX444: Self = FourCC::from(*b"RX12");
+    /// 16 bpp bgrx with 4 bits each.
+    pub const BGRX444: Self = FourCC::from(*b"BX12");
+
+    const fn from(arr: [u8; 4]) -> Self {
+        // FourCC(u32::from_be_bytes(arr)); not yet stable as const-fn
+        FourCC(arr[0] as u32 | (arr[1] as u32) << 8 | (arr[2] as u32) << 16 | (arr[3] as u32) << 24)
+    }
+
+    fn info(self) -> Result<DrmFormatInfo, BadDrmError> {
+        Err(BadDrmError { _private: () })
+    }
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -183,6 +183,10 @@ pub trait Mend<T: Layout> {
 /// type `Converted` in case of success. This is very similar to the method `Vec::take` and others.
 ///
 /// It is expected that the `byte_len` is `0` after the operation.
+///
+/// This trait is _not_ simply a clone of `Default`. While we expect that the described image
+/// contains no bytes after the operation other data such as channel count, color space
+/// information, image plane order, alpha interpretation should be retained.
 pub trait Take: Layout {
     fn take(&mut self) -> Self;
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -191,6 +191,28 @@ pub trait Take: Layout {
     fn take(&mut self) -> Self;
 }
 
+/// Describes an image coordinate.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Coord(pub u32, pub u32);
+
+impl Coord {
+    pub fn x(self) -> u32 {
+        self.0
+    }
+
+    pub fn y(self) -> u32 {
+        self.1
+    }
+
+    pub fn yx(self) -> (u32, u32) {
+        (self.1, self.0)
+    }
+
+    pub fn xy(self) -> (u32, u32) {
+        (self.0, self.1)
+    }
+}
+
 /// A layout that is a slice of samples.
 ///
 /// These layouts are represented with a slice of a _single_ type of samples. In particular these

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -26,8 +26,13 @@ pub struct Element {
 ///
 /// This property holds for any packed, strided or planar RGB/YCbCr/HSV format as well as chroma
 /// subsampled YUV images and even raw Bayer filtered images.
+pub trait Layout {
+    fn byte_len(&self) -> usize;
+}
+
+/// A dynamic descriptor of an image's layout.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Layout {
+pub struct DynLayout {
     pub(crate) repr: LayoutRepr,
 }
 
@@ -71,7 +76,7 @@ impl Element {
     }
 }
 
-impl Layout {
+impl DynLayout {
     pub fn byte_len(self) -> usize {
         match self.repr {
             LayoutRepr::Matrix(matrix) => matrix.byte_len(),
@@ -168,17 +173,17 @@ impl Yuv420p {
     }
 }
 
-impl From<Matrix> for Layout {
+impl From<Matrix> for DynLayout {
     fn from(matrix: Matrix) -> Self {
-        Layout {
+        DynLayout {
             repr: LayoutRepr::Matrix(matrix),
         }
     }
 }
 
-impl From<Yuv420p> for Layout {
+impl From<Yuv420p> for DynLayout {
     fn from(matrix: Yuv420p) -> Self {
-        Layout {
+        DynLayout {
             repr: LayoutRepr::Yuv420p(matrix),
         }
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -18,6 +18,43 @@ pub struct Element {
     align: usize,
 }
 
+/// A direct rendering manager format info.
+///
+/// This structure is a cleaned-up version of the one present in the Linux kernel rendering
+/// subsystem, with deprecated fields removed. It is not a `Layout` itself since it is not
+/// guaranteed to be internally consistent, it does not yet describe width and height or it might
+/// otherwise not be supported. Try to convert it to a `DynLayout`.
+///
+/// See: the Linux kernel header `drm/drm_fourcc.h`.
+#[derive(Clone, Copy, Debug, Hash)]
+pub struct DrmFormatInfo {
+    /// The 4CC format identifier.
+    pub format: FourCC,
+    /// The number of image color planes (1 to 3).
+    pub num_planes: u8,
+    /// The number of bytes per block.
+    pub char_per_block: [u8; 4],
+    /// The width of a block in pixels.
+    pub block_w: [u8; 4],
+    /// The height of a block in pixels.
+    pub block_h: [u8; 4],
+    /// The horizontal chroma subsampling factor.
+    pub hsub: u8,
+    /// The vertical chroma subsampling factor.
+    pub vsub: u8,
+    /// Does the format embed an alpha component?
+    pub has_alpha: bool,
+    /// Is it a YUV format?
+    pub is_yuv: bool,
+}
+
+/// A 4CC format identifier.
+///
+/// This exist to define the common formats as constants and to typify the conversion and
+/// representation of values involved. The code is always stored as little endian.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FourCC(u32);
+
 /// A descriptor of the layout of image bytes.
 ///
 /// There is no color space and no strict type interpretation here, just some mapping to required
@@ -114,6 +151,46 @@ impl Element {
 
     pub const fn align(self) -> usize {
         self.size
+    }
+}
+
+impl DrmFormatInfo {
+    /// Create a layout with particular dimensions.
+    ///
+    /// This is a partial function to represent that not all descriptors can be convert to a
+    /// possible dynamic layouts. No successful conversion will get removed across SemVer
+    /// compatible versions.
+    pub fn into_layout(self, _: u32, _: u32) -> Option<DynLayout> {
+        None
+    }
+}
+
+impl FourCC {
+    /* Relevant formats according to Linux header `uapi/drm/drm_fourcc.h` */
+    /// The constant denoting an invalid format, e.g. signalling a missing format.
+    pub const INVALID: Self = FourCC(0);
+    /// Single 8 bpp grey color.
+    pub const C8: Self = FourCC::from(*b"C8  ");
+
+    /* 8 bpp rgb */
+    /// 8bpp rgb with 3 bits red, 3 bits green, 2 bits blue.
+    pub const RGB332: Self = FourCC::from(*b"RGB8");
+    /// 8bpp rgb with 2 bits red, 3 bits green, 3 bits blue.
+    pub const BGR332: Self = FourCC::from(*b"BGR8");
+
+    /* 16 bpp rgb */
+    /// 16 bpp xrgb with 4 bits each.
+    pub const XRGB444: Self = FourCC::from(*b"XR12");
+    /// 16 bpp xbgr with 4 bits each.
+    pub const XBRG444: Self = FourCC::from(*b"XB12");
+    /// 16 bpp rgbx with 4 bits each.
+    pub const RGBX444: Self = FourCC::from(*b"RX12");
+    /// 16 bpp bgrx with 4 bits each.
+    pub const BGRX444: Self = FourCC::from(*b"BX12");
+
+    const fn from(arr: [u8; 4]) -> Self {
+        // FourCC(u32::from_be_bytes(arr)); not yet stable as const-fn
+        FourCC(arr[0] as u32 | (arr[1] as u32) << 8 | (arr[2] as u32) << 16 | (arr[3] as u32) << 24)
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -283,4 +283,4 @@ impl<P> Clone for TMatrix<P> {
     }
 }
 
-impl<P> Copy for TMatrix<P> { }
+impl<P> Copy for TMatrix<P> {}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,0 +1,104 @@
+//! A module for different pixel layouts.
+use crate::AsPixel;
+
+/// Describes the byte layout of an element, untyped.
+///
+/// This is not so different from `Pixel` and `Layout` but is a combination of both. It has the
+/// same invariants on alignment as the former which being untyped like the latter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Element {
+    size: usize,
+    align: usize,
+}
+
+/// A matrix of packed pixels (channel groups).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Matrix {
+    element: Element,
+    first_dim: usize,
+    second_dim: usize,
+}
+
+/// A column major image of packed pixels (channel groups).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ColumnMajor {
+    element: Element,
+    backing: Matrix,
+    view: Matrix,
+}
+
+/// A row major image of packed pixels (channel groups).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct RowMajor {
+    matrix: Matrix,
+}
+
+impl Element {
+    pub fn from_pixel<P: AsPixel>() -> Self {
+        let pix = P::pixel();
+        Element {
+            size: pix.size(),
+            align: pix.align(),
+        }
+    }
+
+    pub const fn size(self) -> usize {
+        self.size
+    }
+
+    pub const fn align(self) -> usize {
+        self.size
+    }
+}
+
+impl Matrix {
+    pub fn from_width_height(
+        element: Element,
+        first_dim: usize,
+        second_dim: usize,
+    ) -> Option<Self> {
+        let max_index = first_dim.checked_mul(second_dim)?;
+        let _ = max_index.checked_mul(element.size)?;
+
+        Some(Matrix {
+            element,
+            first_dim,
+            second_dim,
+        })
+    }
+
+    /// Get the required bytes for this layout.
+    pub const fn byte_len(self) -> usize {
+        // Exactly this does not overflow due to construction.
+        self.element.size * self.len()
+    }
+
+    /// The number of pixels in this layout
+    pub const fn len(self) -> usize {
+        self.first_dim * self.second_dim
+    }
+
+    pub fn offset(self, coord1: usize, coord2: usize) -> Option<usize> {
+        if self.first_dim >= coord1 || self.second_dim >= coord2 {
+            None
+        } else {
+            Some(self.offset_unchecked(coord1, coord2))
+        }
+    }
+
+    pub const fn offset_unchecked(self, coord1: usize, coord2: usize) -> usize {
+        coord1 + coord2 * self.first_dim
+    }
+
+    pub fn byte_offset(self, coord1: usize, coord2: usize) -> Option<usize> {
+        if self.first_dim >= coord1 || self.second_dim >= coord2 {
+            None
+        } else {
+            Some(self.byte_offset_unchecked(coord1, coord2))
+        }
+    }
+
+    pub const fn byte_offset_unchecked(self, coord1: usize, coord2: usize) -> usize {
+        (coord1 + coord2 * self.first_dim) * self.element.size
+    }
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -37,9 +37,15 @@ pub trait Layout {
     fn byte_len(&self) -> usize;
 }
 
-/// A layout that uses a slice of samples.
+/// A layout that is a slice of samples.
+///
+/// These layouts are represented with a slice of a _single_ type of samples. In particular these
+/// can be addressed and mutated independently.
 pub trait SampleSlice: Layout {
+    /// The sample type itself.
     type Sample;
+
+    /// Get the sample description.
     fn sample(&self) -> Pixel<Self::Sample>;
 
     /// The number of samples.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -91,9 +91,9 @@ pub trait Layout {
 /// ```ignore
 /// struct Local;
 ///
-/// impl Trait for Local { … }
+/// impl Trait for Local { /* … */ }
 ///
-/// impl<T: Trait> Decay<T> for Local { … }
+/// impl<T: Trait> Decay<T> for Local { /* … */ }
 /// ```
 ///
 /// Otherwise, the instantiation `T = U` would collide with the reflexive impl.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -18,42 +18,7 @@ pub struct Element {
     align: usize,
 }
 
-/// A direct rendering manager format info.
-///
-/// This structure is a cleaned-up version of the one present in the Linux kernel rendering
-/// subsystem, with deprecated fields removed. It is not a `Layout` itself since it is not
-/// guaranteed to be internally consistent, it does not yet describe width and height or it might
-/// otherwise not be supported. Try to convert it to a `DynLayout`.
-///
-/// See: the Linux kernel header `drm/drm_fourcc.h`.
-#[derive(Clone, Copy, Debug, Hash)]
-pub struct DrmFormatInfo {
-    /// The 4CC format identifier.
-    pub format: FourCC,
-    /// The number of image color planes (1 to 3).
-    pub num_planes: u8,
-    /// The number of bytes per block.
-    pub char_per_block: [u8; 4],
-    /// The width of a block in pixels.
-    pub block_w: [u8; 4],
-    /// The height of a block in pixels.
-    pub block_h: [u8; 4],
-    /// The horizontal chroma subsampling factor.
-    pub hsub: u8,
-    /// The vertical chroma subsampling factor.
-    pub vsub: u8,
-    /// Does the format embed an alpha component?
-    pub has_alpha: bool,
-    /// Is it a YUV format?
-    pub is_yuv: bool,
-}
-
-/// A 4CC format identifier.
-///
-/// This exist to define the common formats as constants and to typify the conversion and
-/// representation of values involved. The code is always stored as little endian.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct FourCC(u32);
+pub use crate::drm::{DrmFormatInfo, FourCC};
 
 /// A descriptor of the layout of image bytes.
 ///
@@ -299,46 +264,6 @@ impl Element {
 
     pub const fn align(self) -> usize {
         self.size
-    }
-}
-
-impl DrmFormatInfo {
-    /// Create a layout with particular dimensions.
-    ///
-    /// This is a partial function to represent that not all descriptors can be convert to a
-    /// possible dynamic layouts. No successful conversion will get removed across SemVer
-    /// compatible versions.
-    pub fn into_layout(self, _: u32, _: u32) -> Option<DynLayout> {
-        None
-    }
-}
-
-impl FourCC {
-    /* Relevant formats according to Linux header `uapi/drm/drm_fourcc.h` */
-    /// The constant denoting an invalid format, e.g. signalling a missing format.
-    pub const INVALID: Self = FourCC(0);
-    /// Single 8 bpp grey color.
-    pub const C8: Self = FourCC::from(*b"C8  ");
-
-    /* 8 bpp rgb */
-    /// 8bpp rgb with 3 bits red, 3 bits green, 2 bits blue.
-    pub const RGB332: Self = FourCC::from(*b"RGB8");
-    /// 8bpp rgb with 2 bits red, 3 bits green, 3 bits blue.
-    pub const BGR332: Self = FourCC::from(*b"BGR8");
-
-    /* 16 bpp rgb */
-    /// 16 bpp xrgb with 4 bits each.
-    pub const XRGB444: Self = FourCC::from(*b"XR12");
-    /// 16 bpp xbgr with 4 bits each.
-    pub const XBRG444: Self = FourCC::from(*b"XB12");
-    /// 16 bpp rgbx with 4 bits each.
-    pub const RGBX444: Self = FourCC::from(*b"RX12");
-    /// 16 bpp bgrx with 4 bits each.
-    pub const BGRX444: Self = FourCC::from(*b"BX12");
-
-    const fn from(arr: [u8; 4]) -> Self {
-        // FourCC(u32::from_be_bytes(arr)); not yet stable as const-fn
-        FourCC(arr[0] as u32 | (arr[1] as u32) << 8 | (arr[2] as u32) << 16 | (arr[3] as u32) << 24)
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -11,6 +11,32 @@ pub struct Element {
     align: usize,
 }
 
+/// A descriptor of the layout of image bytes.
+///
+/// There is no color space and no strict type interpretation here, just some mapping to required
+/// bytes for such a fixed buffer and a width and height of the described image. This means that
+/// the byte usage for a particular buffer needs to be independent of the content, in particular
+/// can not be based on compressibility.
+///
+/// There is one more thing that differentiates an image from an encoded format. It is expected
+/// that the image can be unfolded into some matrix of independent pixels (with potentially
+/// multiple channels) without any arithmetic or conversion function. Independent here means that,
+/// when supplied with the missing color space and type information, there should exist an
+/// `Fn(U) -> T` that can map these pixels independently into some linear color space.
+///
+/// This property holds for any packed, strided or planar RGB/YCbCr/HSV format as well as chroma
+/// subsampled YUV images and even raw Bayer filtered images.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Layout {
+    pub(crate) repr: LayoutRepr,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum LayoutRepr {
+    Matrix(Matrix),
+    Yuv420p(Yuv420p),
+}
+
 /// A matrix of packed pixels (channel groups).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Matrix {
@@ -19,18 +45,12 @@ pub struct Matrix {
     second_dim: usize,
 }
 
-/// A column major image of packed pixels (channel groups).
+/// Planar chroma 2×2 block-wise sub-sampled image.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct ColumnMajor {
-    element: Element,
-    backing: Matrix,
-    view: Matrix,
-}
-
-/// A row major image of packed pixels (channel groups).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct RowMajor {
-    matrix: Matrix,
+pub struct Yuv420p {
+    channel: Element,
+    width: u32,
+    height: u32,
 }
 
 impl Element {
@@ -51,7 +71,24 @@ impl Element {
     }
 }
 
+impl Layout {
+    pub fn byte_len(self) -> usize {
+        match self.repr {
+            LayoutRepr::Matrix(matrix) => matrix.byte_len(),
+            LayoutRepr::Yuv420p(matrix) => matrix.byte_len(),
+        }
+    }
+}
+
 impl Matrix {
+    pub fn empty(element: Element) -> Self {
+        Matrix {
+            element,
+            first_dim: 0,
+            second_dim: 0,
+        }
+    }
+
     pub fn from_width_height(
         element: Element,
         first_dim: usize,
@@ -100,5 +137,49 @@ impl Matrix {
 
     pub const fn byte_offset_unchecked(self, coord1: usize, coord2: usize) -> usize {
         (coord1 + coord2 * self.first_dim) * self.element.size
+    }
+}
+
+impl Yuv420p {
+    pub fn from_width_height(channel: Element, width: u32, height: u32) -> Option<Self> {
+        use core::convert::TryFrom;
+        if width % 2 != 0 || height % 2 != 0 {
+            return None;
+        }
+
+        let mwidth = usize::try_from(width).ok()?;
+        let mheight = usize::try_from(height).ok()?;
+
+        let y_count = mwidth.checked_mul(mheight)?;
+        let uv_count = y_count / 2;
+
+        let count = y_count.checked_add(uv_count)?;
+        let total = count.checked_mul(channel.size)?;
+        Some(Yuv420p {
+            channel,
+            width,
+            height,
+        })
+    }
+
+    pub const fn byte_len(self) -> usize {
+        let ylen = (self.width as usize) * (self.height as usize) * self.channel.size;
+        ylen + ylen / 2
+    }
+}
+
+impl From<Matrix> for Layout {
+    fn from(matrix: Matrix) -> Self {
+        Layout {
+            repr: LayoutRepr::Matrix(matrix),
+        }
+    }
+}
+
+impl From<Yuv420p> for Layout {
+    fn from(matrix: Yuv420p) -> Self {
+        Layout {
+            repr: LayoutRepr::Yuv420p(matrix),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ extern crate alloc;
 
 mod buf;
 mod canvas;
+mod drm;
 pub mod layout;
 mod matrix;
 mod pixel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,13 @@
 extern crate alloc;
 
 mod buf;
+mod canvas;
 mod layout;
 mod matrix;
 mod pixel;
 mod rec;
 
+pub use self::canvas::Canvas;
 pub use self::matrix::{Layout, Matrix, MatrixReuseError};
 pub use self::pixel::{AsPixel, Pixel};
 pub use self::rec::{Rec, ReuseError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 extern crate alloc;
 
 mod buf;
+mod layout;
 mod matrix;
 mod pixel;
 mod rec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate alloc;
 
 mod buf;
 mod canvas;
-mod layout;
+pub mod layout;
 mod matrix;
 mod pixel;
 mod rec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // Distributed under The MIT License (MIT)
 //
 // Copyright (c) 2019 The `image-rs` developers
-//! # Canvas
+//! # Matrix
 //!
 //! An image canvas compatible with transmuting its byte content.
 //!
@@ -9,8 +9,8 @@
 //!
 //! ```
 //! # fn send_over_network(_: &[u8]) { };
-//! use canvas::Canvas;
-//! let mut canvas = Canvas::with_width_and_height(400, 400);
+//! use canvas::Matrix;
+//! let mut canvas = Matrix::with_width_and_height(400, 400);
 //!
 //! // Draw a bright red line.
 //! for i in 0..400 {
@@ -33,11 +33,11 @@
 extern crate alloc;
 
 mod buf;
-mod canvas;
+mod matrix;
 mod pixel;
 mod rec;
 
-pub use self::canvas::{Canvas, CanvasReuseError, Layout};
+pub use self::matrix::{Layout, Matrix, MatrixReuseError};
 pub use self::pixel::{AsPixel, Pixel};
 pub use self::rec::{Rec, ReuseError};
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -6,9 +6,9 @@ use core::{cmp, fmt};
 
 use bytemuck::Pod;
 
-use crate::{layout, AsPixel, Pixel, Rec, ReuseError};
-use crate::canvas::RawCanvas;
 use crate::buf::Buffer;
+use crate::canvas::RawCanvas;
+use crate::{layout, AsPixel, Pixel, Rec, ReuseError};
 
 /// A 2d, width-major matrix of pixels.
 ///

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -7,7 +7,7 @@ use core::{cmp, fmt};
 use bytemuck::Pod;
 
 use crate::buf::Buffer;
-use crate::canvas::RawCanvas;
+use crate::canvas::{Canvas, RawCanvas};
 use crate::{layout, AsPixel, Pixel, Rec, ReuseError};
 
 /// A 2d, width-major matrix of pixels.
@@ -464,6 +464,22 @@ where
     /// would exceed the platform address space.
     pub fn layout(&self) -> Option<Layout<Q>> {
         self.layout
+    }
+}
+
+impl<P: Pod> From<Canvas<Layout<P>>> for Matrix<P> {
+    fn from(canvas: Canvas<Layout<P>>) -> Self {
+        let layout = *canvas.layout();
+        let rec = canvas.into_rec();
+        Self::new_raw(rec, layout)
+    }
+}
+
+impl<P: Pod> From<Matrix<P>> for Canvas<Layout<P>> {
+    fn from(matrix: Matrix<P>) -> Self {
+        let layout = matrix.layout();
+        let rec = matrix.into_rec();
+        Canvas::from_rec(rec, layout)
     }
 }
 

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,6 +1,6 @@
 // Distributed under The MIT License (MIT)
 //
-// Copyright (c) 2019 The `image-rs` developers
+// Copyright (c) 2019, 2020 The `image-rs` developers
 use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use core::marker::PhantomData;
 use core::{fmt, mem};
@@ -50,6 +50,7 @@ pub(crate) mod constants {
     }
 
     constant_pixels!(
+        (EMPTY, ()),
         (I8, i8),
         (U8, u8),
         (I16, i16),

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2019, 2020 The `image-rs` developers
 use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use core::marker::PhantomData;
-use core::{fmt, mem};
+use core::{fmt, hash, mem};
 
 /// Marker struct to denote a pixel type.
 ///
@@ -129,4 +129,8 @@ impl<P> fmt::Debug for Pixel<P> {
             .field("align", &self.align())
             .finish()
     }
+}
+
+impl<P> hash::Hash for Pixel<P> {
+    fn hash<H: hash::Hasher>(&self, _: &mut H) {}
 }

--- a/src/rec.rs
+++ b/src/rec.rs
@@ -42,8 +42,8 @@ pub struct Rec<P: Pod> {
 /// };
 /// ```
 pub struct ReuseError {
-    requested: Option<usize>,
-    capacity: usize,
+    pub(crate) requested: Option<usize>,
+    pub(crate) capacity: usize,
 }
 
 impl<P: Pod> Rec<P> {
@@ -89,6 +89,14 @@ impl<P: Pod> Rec<P> {
             inner: Buffer::new(mem_size),
             length: mem_size,
             pixel,
+        }
+    }
+
+    pub(crate) fn from_buffer(inner: Buffer, pixel: Pixel<P>) -> Self {
+        Rec {
+            inner,
+            pixel,
+            length: 0,
         }
     }
 

--- a/src/rec.rs
+++ b/src/rec.rs
@@ -306,6 +306,10 @@ impl<P: Pod> Rec<P> {
     fn buf_mut(&mut self) -> &mut buf {
         &mut self.inner[..self.length]
     }
+
+    pub(crate) fn into_inner(self) -> Buffer {
+        self.inner
+    }
 }
 
 fn mem_size<P>(pixel: Pixel<P>, count: usize) -> usize {


### PR DESCRIPTION
A large scale refactor that allows more flexibility with images. The old main type is renamed to `Matrix`. The new `Canvas` implementation no longer *requires* knowing the sample type and is instead parameterized over a `Layout`, that may dynamically describe the use of the image's bytes. The old type has been reimplemented with a specialized version of this `Canvas` to proof its applicability.

- [x] Review blanket impls of `Decay<T> for SpecificLayout`. We can not add them later so look at the defined layouts and see if we missed something obvious.

Closes: #15 