### PR TITLE
Run rustfmt only once, on stable linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ os:
 rust:
     - stable
     - nightly
-
-before_install:
-    - rustup component add rustfmt
-    - cargo fmt --version
+jobs:
+    include:
+        - name: rustfmt
+          before_install:
+              - rustup component add rustfmt
+              - cargo fmt --version
+          script: cargo fmt --all -- --check
 
 script:
-    - cargo fmt --all -- --check
     - cargo build -v && cargo test -v && cargo doc -v


### PR DESCRIPTION
Otherwise risks breakage for no gains, as rustfmt should be architecture
and feature independent.