### PR TITLE
Small fixes and consistency changes

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -172,6 +172,7 @@ impl buf {
     ///
     /// The alignment of `P` is already checked to be smaller than `MAX_ALIGN` through the
     /// constructor of `Pixel`.
+    // FIXME: decide to use naming scheme of `as_bytes_mut` or `as_mut_slice`.
     pub fn as_mut_pixels<P>(&mut self, pixel: Pixel<P>) -> &mut [P] {
         pixel.cast_mut_buf(self)
     }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -124,6 +124,19 @@ impl<L: Layout> Canvas<L> {
         self.inner.as_bytes_mut()
     }
 
+    /// If necessary, reallocate the buffer to fit the layout.
+    ///
+    /// Call this method after having mutated a layout with [`layout_mut_unguarded`] whenever you
+    /// are not sure that the layout did not grow. This will ensure the contract that the internal
+    /// buffer is large enough for the layout.
+    ///
+    /// # Panics
+    ///
+    /// This method panics when the allocation of the new buffer fails.
+    pub fn ensure_layout(&mut self) {
+        self.inner.mutate_layout(|_| ());
+    }
+
     /// Decay into a canvas with less specific layout.
     ///
     /// See the [`Decay`] trait for an explanation of this operation.

--- a/src/drm.rs
+++ b/src/drm.rs
@@ -310,7 +310,7 @@ impl DrmFormatInfo {
                 if plane == PlaneIdx::First {
                     pixel::constants::U8.into()
                 } else {
-                    pixel::constants::U16.into()
+                    pixel::constants::U8.array2().into()
                 }
             }
             FourCC::YUV410
@@ -974,14 +974,14 @@ fn simple_planes() {
     let first = first.strided().spec();
     assert_eq!(first.width, 900);
     assert_eq!(first.height, 600);
-    assert_eq!(first.element_size, 2);
+    assert_eq!(first.element.size(), 2);
 
     assert_eq!(second.width(), 900);
     assert_eq!(second.height(), 600);
     let second = second.strided().spec();
     assert_eq!(second.width, 900);
     assert_eq!(second.height, 600);
-    assert_eq!(second.element_size, 1);
+    assert_eq!(second.element.size(), 1);
 }
 
 #[test]
@@ -1002,12 +1002,12 @@ fn yuv_planes() {
     let first = first.strided().spec();
     assert_eq!(first.width, 900);
     assert_eq!(first.height, 600);
-    assert_eq!(first.element_size, 1);
+    assert_eq!(first.element.size(), 1);
 
     assert_eq!(second.width(), 450);
     assert_eq!(second.height(), 300);
     let second = second.strided().spec();
     assert_eq!(second.width, 450);
     assert_eq!(second.height, 300);
-    assert_eq!(second.element_size, 2);
+    assert_eq!(second.element.size(), 2);
 }

--- a/src/drm.rs
+++ b/src/drm.rs
@@ -66,7 +66,7 @@ struct PlaneInfo {
 /// A descriptor for a single frame buffer.
 ///
 /// In Linux, used to request new buffers or reallocation of buffers. Here, we use it similarly as
-/// the builder type to fallibly construct a `DrmFramebuffer`, a complete layout descriptor for one
+/// the builder type to fallibly construct a `DrmLayout`, a complete layout descriptor for one
 /// sized image.
 ///
 /// See: the Linux kernel header `drm/drm_mode.h`.
@@ -83,8 +83,9 @@ pub struct DrmFramebufferCmd {
 
 /// The filled-in info about a frame buffer.
 ///
-/// This is equivalent to `drm_framebuffer`, minus the kernel internal stuff.
-pub(crate) struct DrmFramebuffer {
+/// This is equivalent to `drm_framebuffer`, minus the kernel internal stuff. This does not own any
+/// image data of its own, it's just an internally validated descriptor.
+pub(crate) struct DrmFramebufferInfo {
     pub format: DrmFormatInfo,
     pub pitches: [u32; 4],
     pub offsets: [u32; 4],
@@ -101,7 +102,7 @@ pub(crate) struct DrmFramebuffer {
 /// fresh. It might be relaxed later when we find a strategy to ensure this through other means.
 pub struct DrmLayout {
     /// The frame buffer layout, checked for internal consistency.
-    pub(crate) info: DrmFramebuffer,
+    pub(crate) info: DrmFramebufferInfo,
     pub(crate) total_len: usize,
 }
 
@@ -430,7 +431,7 @@ impl DrmLayout {
             return Err(BadDrmKind::IllegalVsub.into());
         }
 
-        let descriptor = DrmFramebuffer {
+        let descriptor = DrmFramebufferInfo {
             format: format_info,
             pitches: info.pitches,
             offsets: info.offsets,
@@ -493,12 +494,12 @@ impl DrmLayout {
     }
 
     /// The apparent width as a usize, as validated in constructor.
-    fn width(&self) -> usize {
+    pub fn width(&self) -> usize {
         self.info.width as usize
     }
 
     /// The apparent height as a usize, as validated in constructor.
-    fn height(&self) -> usize {
+    pub fn height(&self) -> usize {
         self.info.height as usize
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,7 @@
 //! A module for different pixel layouts.
 use crate::pixel::MaxAligned;
 use crate::{AsPixel, Pixel};
+use ::alloc::boxed::Box;
 use core::{alloc, cmp};
 
 /// A byte layout that only describes the user bytes.
@@ -581,6 +582,18 @@ impl<P> From<Pixel<P>> for Element {
             size: pix.size(),
             align: pix.align(),
         }
+    }
+}
+
+impl<L: Layout + ?Sized> Layout for Box<L> {
+    fn byte_len(&self) -> usize {
+        (**self).byte_len()
+    }
+}
+
+impl<L: Layout> Decay<L> for Box<L> {
+    fn decay(from: L) -> Box<L> {
+        Box::new(from)
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -302,6 +302,17 @@ impl Element {
         })
     }
 
+    /// Create an element having the smaller of both sizes and alignments.
+    #[must_use = "This does not modify `self`."]
+    pub fn infimum(self, other: Self) -> Element {
+        // We still have size divisible by align. Whatever the smaller of both, it's divisible by
+        // its align and thus also by the min of both alignments.
+        Element {
+            size: self.size.min(other.size),
+            align: self.align.min(other.align),
+        }
+    }
+
     /// Get the size of the element.
     pub const fn size(self) -> usize {
         self.size

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,7 +1,7 @@
 //! A module for different pixel layouts.
 use crate::pixel::MaxAligned;
 use crate::{AsPixel, Pixel};
-use core::alloc;
+use core::{alloc, cmp};
 
 /// A byte layout that only describes the user bytes.
 ///
@@ -13,8 +13,14 @@ pub struct Bytes(pub usize);
 /// Describes the byte layout of an element, untyped.
 ///
 /// This is not so different from `Pixel` and `Layout` but is a combination of both. It has the
-/// same invariants on alignment as the former which being untyped like the latter.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// same invariants on alignment as the former which being untyped like the latter. The alignment
+/// of an element must be at most that of [`MaxAligned`] and the size must be a multiple of its
+/// alignment.
+///
+/// This type is a lower semi lattice. That is, given two elements the type formed by taking the
+/// minimum of size and alignment individually will always form another valid element. This
+/// operation is implemented in the [`infimum`] method.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, Hash)]
 pub struct Element {
     size: usize,
     align: usize,
@@ -282,6 +288,17 @@ impl Element {
         }
     }
 
+    /// An element with maximum size and no alignment requirements.
+    ///
+    /// This constructor is mainly useful for the purpose of using it as a modifier. When used with
+    /// [`infimum`] it will only shrink the alignment and keep the size unchanged.
+    pub const MAX_SIZE: Self = {
+        Element {
+            size: isize::MAX as usize,
+            align: 1,
+        }
+    };
+
     /// Create an element for a fictional type with specific layout.
     ///
     /// It's up to the caller to define or use an actual type with that same layout later. This
@@ -300,6 +317,27 @@ impl Element {
             size: layout.size(),
             align: layout.align(),
         })
+    }
+
+    /// Convert this into a type layout.
+    ///
+    /// This can never fail as `Element` refines the standard library layout type.
+    pub fn layout(self) -> alloc::Layout {
+        alloc::Layout::from_size_align(self.size, self.align).expect("Valid layout")
+    }
+
+    /// Reduce the alignment of the element.
+    ///
+    /// This will perform the same modification as `repr(packed)` on the element's type.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if `align` is not a valid alignment.
+    #[must_use = "This does not modify `self`."]
+    pub fn packed(self, align: usize) -> Element {
+        assert!(align.is_power_of_two());
+        let align = self.align.min(align);
+        Element { align, ..self }
     }
 
     /// Create an element having the smaller of both sizes and alignments.
@@ -542,6 +580,42 @@ impl<P> From<Pixel<P>> for Element {
         Element {
             size: pix.size(),
             align: pix.align(),
+        }
+    }
+}
+
+/// The partial order of elements is defined by comparing size and alignment.
+///
+/// This turns it into a semi-lattice structure, with infimum implementing the meet operation. For
+/// example, the following comparison all hold:
+///
+/// ```
+/// # use canvas::pixels::{U8, U16};
+/// # use canvas::layout::Element;
+/// let u8 = Element::from(U8);
+/// let u8x2 = Element::from(U8.array2());
+/// let u8x3 = Element::from(U8.array3());
+/// let u16 = Element::from(U16);
+///
+/// assert!(u8 < u16, "due to size and alignment");
+/// assert!(u8x2 < u16, "due to its alignment");
+/// assert!(!(u8x3 < u16) && !(u16 < u8x3), "not comparable");
+///
+/// let meet = u8x3.infimum(u16);
+/// assert!(meet <= u8x3);
+/// assert!(meet <= u16);
+/// assert!(meet == u16.packed(1), "We know it precisely here {:?}", meet);
+/// ```
+impl cmp::PartialOrd for Element {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        if self.size == other.size && self.align == other.align {
+            Some(cmp::Ordering::Equal)
+        } else if self.size <= other.size && self.align <= other.align {
+            Some(cmp::Ordering::Less)
+        } else if self.size >= other.size && self.align >= other.align {
+            Some(cmp::Ordering::Greater)
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
Add complementary interface for manipulation of buffers and elements, fix some types such that they follow a common naming and style. Also adds more documentation and conversion utilities.