### PR TITLE
Simplifications for a more stable release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ name = "canvas"
 
 [dependencies]
 bytemuck = "1.3"
+
+[workspace]
+members = [".", "drm"]

--- a/drm/Cargo.toml
+++ b/drm/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "image-canvas-drm"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+image-canvas = { path = "../" }

--- a/drm/src/lib.rs
+++ b/drm/src/lib.rs
@@ -144,7 +144,7 @@ pub enum PlaneIdx {
 /// The layout of one plane of a DRM buffer.
 pub struct PlaneLayout {
     format: PlaneInfo,
-    element: layout::Element,
+    texel: layout::TexelLayout,
     pitch: u32,
     offset: u32,
     width: u32,
@@ -161,7 +161,7 @@ enum BadDrmKind {
     ZeroBlockWidth,
     ZeroBlockHeight,
     OverlappingPlanes,
-    UndescribableElement,
+    UndescribableTexelLayout,
     IllegalPlaneWidth,
     IllegalPlaneHeight,
     LineSize,
@@ -260,16 +260,16 @@ impl DrmFormatInfo {
         Some(height)
     }
 
-    /// The element describing each block (atomic unit) of the described layout.
+    /// The texel describing each block (atomic unit) of the described layout.
     ///
     /// If plane is outside the number of planes of this format or if the blocks can not be
-    /// described by a single element (e.g. they have extrinsic alignment requirements, their size
+    /// described by a single texel (e.g. they have extrinsic alignment requirements, their size
     /// is not divisible by their alignment) then None is returned.
     ///
     /// Blocks that contain multiple same sized channels in separate bytes are represented arrays
     /// of that channel type. In contrast, blocks that hold channels as bitfields are represented
     /// using a large integer, which comes with additional alignment requirements.
-    pub fn block_element(self, plane: PlaneIdx) -> Option<layout::Element> {
+    pub fn block_element(self, plane: PlaneIdx) -> Option<layout::TexelLayout> {
         if usize::from(self.num_planes) <= plane.to_index() {
             return None;
         }
@@ -547,7 +547,7 @@ impl PlaneLayout {
         start..start + len
     }
 
-    fn element(&self) -> layout::Element {
+    fn texel(&self) -> layout::TexelLayout {
         self.element
     }
 
@@ -946,10 +946,10 @@ impl layout::Layout for PlaneLayout {
 
 impl stride::Strided for PlaneLayout {
     fn strided(&self) -> stride::StrideLayout {
-        let element = self.element();
+        let texel = self.texel();
         let width = self.width();
         let height = self.height();
-        let matrix = layout::Matrix::from_width_height(element, width, height)
+        let matrix = layout::Matrix::from_width_height(texel, width, height)
             .expect("Fits in memory because the plane does");
         stride::StrideLayout::with_row_major(matrix)
     }
@@ -1006,14 +1006,14 @@ fn simple_planes() {
     let first = first.strided().spec();
     assert_eq!(first.width, 900);
     assert_eq!(first.height, 600);
-    assert_eq!(first.element.size(), 2);
+    assert_eq!(first.texel.size(), 2);
 
     assert_eq!(second.width(), 900);
     assert_eq!(second.height(), 600);
     let second = second.strided().spec();
     assert_eq!(second.width, 900);
     assert_eq!(second.height, 600);
-    assert_eq!(second.element.size(), 1);
+    assert_eq!(second.texel.size(), 1);
 }
 
 #[test]
@@ -1034,12 +1034,12 @@ fn yuv_planes() {
     let first = first.strided().spec();
     assert_eq!(first.width, 900);
     assert_eq!(first.height, 600);
-    assert_eq!(first.element.size(), 1);
+    assert_eq!(first.texel.size(), 1);
 
     assert_eq!(second.width(), 450);
     assert_eq!(second.height(), 300);
     let second = second.strided().spec();
     assert_eq!(second.width, 450);
     assert_eq!(second.height, 300);
-    assert_eq!(second.element.size(), 2);
+    assert_eq!(second.texel.size(), 2);
 }

--- a/drm/src/lib.rs
+++ b/drm/src/lib.rs
@@ -13,7 +13,7 @@
 //! pixel matrix. Then some of those formats map cleanly to planes of color information that can be
 //! viewed as a matrix with strides, which finally enables useful operations such as
 //! initialization.
-use crate::{layout, pixel, stride};
+use canvas::{layout, pixels, stride};
 use core::convert::TryFrom;
 use core::fmt;
 use core::ops::Range;
@@ -275,7 +275,7 @@ impl DrmFormatInfo {
         }
 
         Some(match self.format {
-            FourCC::C8 | FourCC::RGB332 | FourCC::BGR332 => pixel::constants::U8.into(),
+            FourCC::C8 | FourCC::RGB332 | FourCC::BGR332 => pixels::U8.into(),
             FourCC::XRGB444
             | FourCC::XBGR444
             | FourCC::RGBX444
@@ -285,8 +285,8 @@ impl DrmFormatInfo {
             | FourCC::ARGB444
             | FourCC::ABGR444
             | FourCC::RGBA444
-            | FourCC::BGRA444 => pixel::constants::U16.into(),
-            FourCC::RGB888 | FourCC::BGR888 => pixel::constants::U8.array3().into(),
+            | FourCC::BGRA444 => pixels::U16.into(),
+            FourCC::RGB888 | FourCC::BGR888 => pixels::U8.array3().into(),
             FourCC::XRGB8888
             | FourCC::XBGR8888
             | FourCC::RGBX8888
@@ -294,7 +294,7 @@ impl DrmFormatInfo {
             | FourCC::ARGB8888
             | FourCC::ABGR8888
             | FourCC::RGBA8888
-            | FourCC::BGRA8888 => pixel::constants::U8.array4().into(),
+            | FourCC::BGRA8888 => pixels::U8.array4().into(),
             FourCC::XRGB2101010
             | FourCC::XBGR2101010
             | FourCC::RGBX1010102
@@ -302,34 +302,34 @@ impl DrmFormatInfo {
             | FourCC::ARGB2101010
             | FourCC::ABGR2101010
             | FourCC::RGBA1010102
-            | FourCC::BGRA1010102 => pixel::constants::U32.into(),
+            | FourCC::BGRA1010102 => pixels::U32.into(),
             FourCC::XRGB16161616F
             | FourCC::XBGR16161616F
             | FourCC::ARGB16161616F
-            | FourCC::ABGR16161616F => pixel::constants::U16.array4().into(),
-            FourCC::YUYV | FourCC::YVYU | FourCC::AYUV => pixel::constants::U8.array4().into(),
-            FourCC::VUY101010 => pixel::constants::U32.into(),
-            FourCC::VUY888 => pixel::constants::U8.array3().into(),
+            | FourCC::ABGR16161616F => pixels::U16.array4().into(),
+            FourCC::YUYV | FourCC::YVYU | FourCC::AYUV => pixels::U8.array4().into(),
+            FourCC::VUY101010 => pixels::U32.into(),
+            FourCC::VUY888 => pixels::U8.array3().into(),
             // Actually planar formats.
             FourCC::XRGB888_A8 | FourCC::XBGR888_A8 => {
                 if plane == PlaneIdx::First {
-                    pixel::constants::U8.array4().into()
+                    pixels::U8.array4().into()
                 } else {
-                    pixel::constants::U8.into()
+                    pixels::U8.into()
                 }
             }
             FourCC::RGB888_A8 | FourCC::BGR888_A8 => {
                 if plane == PlaneIdx::First {
-                    pixel::constants::U8.array3().into()
+                    pixels::U8.array3().into()
                 } else {
-                    pixel::constants::U8.into()
+                    pixels::U8.into()
                 }
             }
             FourCC::RGB565_A8 | FourCC::BGR565_A8 => {
                 if plane == PlaneIdx::First {
-                    pixel::constants::U16.into()
+                    pixels::U16.into()
                 } else {
-                    pixel::constants::U8.into()
+                    pixels::U8.into()
                 }
             }
             FourCC::NV12
@@ -339,9 +339,9 @@ impl DrmFormatInfo {
             | FourCC::NV24
             | FourCC::NV42 => {
                 if plane == PlaneIdx::First {
-                    pixel::constants::U8.into()
+                    pixels::U8.into()
                 } else {
-                    pixel::constants::U8.array2().into()
+                    pixels::U8.array2().into()
                 }
             }
             FourCC::YUV410
@@ -353,7 +353,7 @@ impl DrmFormatInfo {
             | FourCC::YUV422
             | FourCC::YVU422
             | FourCC::YUV444
-            | FourCC::YVU444 => pixel::constants::U8.into(),
+            | FourCC::YVU444 => pixels::U8.into(),
             // No element that fits (or not implemented?).
             _ => return None,
         })

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -6,7 +6,7 @@ use core::{borrow, cmp, mem, ops};
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
-use crate::pixel::{constants::MAX, MaxAligned, Texel};
+use crate::texel::{constants::MAX, MaxAligned, Texel};
 
 /// Allocates and manages raw bytes.
 ///
@@ -159,21 +159,21 @@ impl buf {
         &mut self.0
     }
 
-    /// Reinterpret the buffer for the specific pixel type.
+    /// Reinterpret the buffer for the specific texel type.
     ///
     /// The alignment of `P` is already checked to be smaller than `MAX_ALIGN` through the
     /// constructor of `Texel`. The slice will have the maximum length possible but may leave
     /// unused bytes in the end.
-    pub fn as_pixels<P>(&self, pixel: Texel<P>) -> &[P] {
+    pub fn as_texels<P>(&self, pixel: Texel<P>) -> &[P] {
         pixel.cast_buf(self)
     }
 
-    /// Reinterpret the buffer mutable for the specific pixel type.
+    /// Reinterpret the buffer mutable for the specific texel type.
     ///
     /// The alignment of `P` is already checked to be smaller than `MAX_ALIGN` through the
     /// constructor of `Texel`.
     // FIXME: decide to use naming scheme of `as_bytes_mut` or `as_mut_slice`.
-    pub fn as_mut_pixels<P>(&mut self, pixel: Texel<P>) -> &mut [P] {
+    pub fn as_mut_texels<P>(&mut self, pixel: Texel<P>) -> &mut [P] {
         pixel.cast_mut_buf(self)
     }
 
@@ -275,7 +275,7 @@ impl buf {
             ops::Bound::Included(&bound) => bound
                 .checked_add(1)
                 .expect("Range does not specify a valid bound end"),
-            ops::Bound::Unbounded => self.as_pixels(p).len(),
+            ops::Bound::Unbounded => self.as_texels(p).len(),
         };
 
         let len = p_end.checked_sub(p_start).expect("Bound violates order");
@@ -283,13 +283,13 @@ impl buf {
         let q_start = dest;
 
         let _ = self
-            .as_pixels(p)
+            .as_texels(p)
             .get(p_start..)
             .and_then(|slice| slice.get(..len))
             .expect("Source out of bounds");
 
         let _ = self
-            .as_pixels(q)
+            .as_texels(q)
             .get(q_start..)
             .and_then(|slice| slice.get(..len))
             .expect("Destination out of bounds");
@@ -347,9 +347,9 @@ impl buf {
         for idx in 0..len {
             let source_idx = idx + src;
             let target_idx = idx + dest;
-            let source = p.copy_val(&self.as_pixels(p)[source_idx]);
+            let source = p.copy_val(&self.as_texels(p)[source_idx]);
             let target = f(source);
-            self.as_mut_pixels(q)[target_idx] = target;
+            self.as_mut_texels(q)[target_idx] = target;
         }
     }
 
@@ -366,9 +366,9 @@ impl buf {
         for idx in (0..len).rev() {
             let source_idx = idx + src;
             let target_idx = idx + dest;
-            let source = p.copy_val(&self.as_pixels(p)[source_idx]);
+            let source = p.copy_val(&self.as_texels(p)[source_idx]);
             let target = f(source);
-            self.as_mut_pixels(q)[target_idx] = target;
+            self.as_mut_texels(q)[target_idx] = target;
         }
     }
 }
@@ -547,12 +547,12 @@ impl ops::IndexMut<ops::RangeTo<usize>> for buf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pixels::{MAX, U16, U32, U8};
+    use crate::texels::{MAX, U16, U32, U8};
 
     #[test]
     fn single_max_element() {
         let mut buffer = Buffer::new(mem::size_of::<MaxAligned>());
-        let slice = buffer.as_mut_pixels(MAX);
+        let slice = buffer.as_mut_texels(MAX);
         assert!(slice.len() == 1);
     }
 
@@ -574,26 +574,26 @@ mod tests {
     #[test]
     fn reinterpret() {
         let mut buffer = Buffer::new(mem::size_of::<u32>());
-        assert!(buffer.as_mut_pixels(U32).len() >= 1);
+        assert!(buffer.as_mut_texels(U32).len() >= 1);
         buffer
-            .as_mut_pixels(U16)
+            .as_mut_texels(U16)
             .iter_mut()
             .for_each(|p| *p = 0x0f0f);
         buffer
-            .as_pixels(U32)
+            .as_texels(U32)
             .iter()
             .for_each(|p| assert_eq!(*p, 0x0f0f0f0f));
         buffer
-            .as_pixels(U8)
+            .as_texels(U8)
             .iter()
             .for_each(|p| assert_eq!(*p, 0x0f));
 
         buffer
-            .as_mut_pixels(U8)
+            .as_mut_texels(U8)
             .iter_mut()
             .enumerate()
             .for_each(|(idx, p)| *p = idx as u8);
-        assert_eq!(u32::from_be(buffer.as_pixels(U32)[0]), 0x00010203);
+        assert_eq!(u32::from_be(buffer.as_texels(U32)[0]), 0x00010203);
     }
 
     #[test]
@@ -601,7 +601,7 @@ mod tests {
         const LEN: usize = 10;
         let mut buffer = Buffer::new(LEN * mem::size_of::<u32>());
         buffer
-            .as_mut_pixels(U32)
+            .as_mut_texels(U32)
             .iter_mut()
             .enumerate()
             .for_each(|(idx, p)| *p = idx as u32);
@@ -612,7 +612,7 @@ mod tests {
 
         // Back to where we started.
         assert_eq!(
-            buffer.as_pixels(U32)[..LEN].to_vec(),
+            buffer.as_texels(U32)[..LEN].to_vec(),
             (0..LEN as u32).collect::<Vec<_>>()
         );
 
@@ -621,7 +621,7 @@ mod tests {
         buffer.map_within(3 * LEN..4 * LEN, 0, |n: u8| n as u32, U8, U32);
 
         assert_eq!(
-            buffer.as_pixels(U32)[..LEN].to_vec(),
+            buffer.as_texels(U32)[..LEN].to_vec(),
             (0..LEN as u32).collect::<Vec<_>>()
         );
     }

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -294,6 +294,7 @@ impl buf {
             .and_then(|slice| slice.get(..len))
             .expect("Destination out of bounds");
 
+        // Due to both being Texels.
         assert!(p.size() as isize > 0);
         assert!(q.size() as isize > 0);
 

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -6,7 +6,7 @@ use core::{borrow, cmp, mem, ops};
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
-use crate::pixel::{constants::MAX, MaxAligned, Pixel};
+use crate::pixel::{constants::MAX, MaxAligned, Texel};
 
 /// Allocates and manages raw bytes.
 ///
@@ -162,18 +162,18 @@ impl buf {
     /// Reinterpret the buffer for the specific pixel type.
     ///
     /// The alignment of `P` is already checked to be smaller than `MAX_ALIGN` through the
-    /// constructor of `Pixel`. The slice will have the maximum length possible but may leave
+    /// constructor of `Texel`. The slice will have the maximum length possible but may leave
     /// unused bytes in the end.
-    pub fn as_pixels<P>(&self, pixel: Pixel<P>) -> &[P] {
+    pub fn as_pixels<P>(&self, pixel: Texel<P>) -> &[P] {
         pixel.cast_buf(self)
     }
 
     /// Reinterpret the buffer mutable for the specific pixel type.
     ///
     /// The alignment of `P` is already checked to be smaller than `MAX_ALIGN` through the
-    /// constructor of `Pixel`.
+    /// constructor of `Texel`.
     // FIXME: decide to use naming scheme of `as_bytes_mut` or `as_mut_slice`.
-    pub fn as_mut_pixels<P>(&mut self, pixel: Pixel<P>) -> &mut [P] {
+    pub fn as_mut_pixels<P>(&mut self, pixel: Texel<P>) -> &mut [P] {
         pixel.cast_mut_buf(self)
     }
 
@@ -196,8 +196,8 @@ impl buf {
         src: impl ops::RangeBounds<usize>,
         dest: usize,
         f: impl Fn(P) -> Q,
-        p: Pixel<P>,
-        q: Pixel<Q>,
+        p: Texel<P>,
+        q: Texel<Q>,
     ) {
         // By symmetry, a write sequence that map `src` to `dest` without clobbering any values
         // that need to be read later can be applied in reverse to map `dest` to `src` instead.
@@ -341,8 +341,8 @@ impl buf {
         dest: usize,
         len: usize,
         f: impl Fn(P) -> Q,
-        p: Pixel<P>,
-        q: Pixel<Q>,
+        p: Texel<P>,
+        q: Texel<Q>,
     ) {
         for idx in 0..len {
             let source_idx = idx + src;
@@ -360,8 +360,8 @@ impl buf {
         dest: usize,
         len: usize,
         f: impl Fn(P) -> Q,
-        p: Pixel<P>,
-        q: Pixel<Q>,
+        p: Texel<P>,
+        q: Texel<Q>,
     ) {
         for idx in (0..len).rev() {
             let source_idx = idx + src;

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -71,14 +71,18 @@ pub struct ViewMut<'buf, Layout = Bytes> {
 }
 
 /// A raster layout.
-pub trait Raster<Texel>: Sized {
+///
+/// This is a special form of texels that represent single group of color channels.
+pub trait Raster<Pixel>: Sized {
     fn dimensions(&self) -> Coord;
-    fn get(from: View<Self>, at: Coord) -> Texel;
+    fn get(from: View<Self>, at: Coord) -> Pixel;
 }
 
 /// A raster layout where one can change pixel values independently.
-pub trait RasterMut<Texel>: Raster<Texel> {
-    fn put(into: ViewMut<Self>, at: Coord, val: Texel);
+///
+/// In other words, requires that texels are one-by-one blocks of pixels.
+pub trait RasterMut<Pixel>: Raster<Pixel> {
+    fn put(into: ViewMut<Self>, at: Coord, val: Pixel);
 }
 
 /// Inner buffer implementation.
@@ -222,16 +226,16 @@ impl<L> Canvas<L> {
     ///
     /// This reinterprets the bytes of the buffer. It can be used to view the buffer as any kind of
     /// pixel, regardless of its association with the layout. Use it with care.
-    pub fn as_pixels<P>(&self, pixel: Texel<P>) -> &[P] {
-        self.inner.buffer.as_pixels(pixel)
+    pub fn as_texels<P>(&self, pixel: Texel<P>) -> &[P] {
+        self.inner.buffer.as_texels(pixel)
     }
 
     /// View this buffer as a slice of pixels.
     ///
     /// This reinterprets the bytes of the buffer. It can be used to view the buffer as any kind of
     /// pixel, regardless of its association with the layout. Use it with care.
-    pub fn as_mut_pixels<P>(&mut self, pixel: Texel<P>) -> &mut [P] {
-        self.inner.buffer.as_mut_pixels(pixel)
+    pub fn as_mut_texels<P>(&mut self, pixel: Texel<P>) -> &mut [P] {
+        self.inner.buffer.as_mut_texels(pixel)
     }
 
     /// Get a reference to the layout.
@@ -615,14 +619,14 @@ impl<B: BufferLike, L: SampleSlice> RawCanvas<B, L> {
     }
 
     pub(crate) fn as_slice(&self) -> &[L::Sample] {
-        self.buffer.as_pixels(self.layout.sample())
+        self.buffer.as_texels(self.layout.sample())
     }
 
     pub(crate) fn as_mut_slice(&mut self) -> &mut [L::Sample]
     where
         B: BufferMut,
     {
-        self.buffer.as_mut_pixels(self.layout.sample())
+        self.buffer.as_mut_texels(self.layout.sample())
     }
 
     /// Convert back into an vector-like of sample types.

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -5,7 +5,7 @@ use core::{fmt, ops};
 
 use crate::buf::{buf, Buffer, Cog};
 use crate::layout::{Bytes, Coord, Decay, DynLayout, Layout, Mend, SampleSlice, Take, TryMend};
-use crate::{Pixel, Rec, ReuseError};
+use crate::{Rec, ReuseError, Texel};
 
 /// A owned canvas, parameterized over the layout.
 ///
@@ -71,14 +71,14 @@ pub struct ViewMut<'buf, Layout = Bytes> {
 }
 
 /// A raster layout.
-pub trait Raster<Pixel>: Sized {
+pub trait Raster<Texel>: Sized {
     fn dimensions(&self) -> Coord;
-    fn get(from: View<Self>, at: Coord) -> Pixel;
+    fn get(from: View<Self>, at: Coord) -> Texel;
 }
 
 /// A raster layout where one can change pixel values independently.
-pub trait RasterMut<Pixel>: Raster<Pixel> {
-    fn put(into: ViewMut<Self>, at: Coord, val: Pixel);
+pub trait RasterMut<Texel>: Raster<Texel> {
+    fn put(into: ViewMut<Self>, at: Coord, val: Texel);
 }
 
 /// Inner buffer implementation.
@@ -222,7 +222,7 @@ impl<L> Canvas<L> {
     ///
     /// This reinterprets the bytes of the buffer. It can be used to view the buffer as any kind of
     /// pixel, regardless of its association with the layout. Use it with care.
-    pub fn as_pixels<P>(&self, pixel: Pixel<P>) -> &[P] {
+    pub fn as_pixels<P>(&self, pixel: Texel<P>) -> &[P] {
         self.inner.buffer.as_pixels(pixel)
     }
 
@@ -230,7 +230,7 @@ impl<L> Canvas<L> {
     ///
     /// This reinterprets the bytes of the buffer. It can be used to view the buffer as any kind of
     /// pixel, regardless of its association with the layout. Use it with care.
-    pub fn as_mut_pixels<P>(&mut self, pixel: Pixel<P>) -> &mut [P] {
+    pub fn as_mut_pixels<P>(&mut self, pixel: Texel<P>) -> &mut [P] {
         self.inner.buffer.as_mut_pixels(pixel)
     }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -181,28 +181,6 @@ pub trait Take: Layout {
     fn take(&mut self) -> Self;
 }
 
-/// Describes an image coordinate.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct Coord(pub u32, pub u32);
-
-impl Coord {
-    pub fn x(self) -> u32 {
-        self.0
-    }
-
-    pub fn y(self) -> u32 {
-        self.1
-    }
-
-    pub fn yx(self) -> (u32, u32) {
-        (self.1, self.0)
-    }
-
-    pub fn xy(self) -> (u32, u32) {
-        (self.0, self.1)
-    }
-}
-
 /// A layout that is a slice of samples.
 ///
 /// These layouts are represented with a slice of a _single_ type of samples. In particular these
@@ -458,6 +436,18 @@ impl Yuv420p {
 impl Layout for Bytes {
     fn byte_len(&self) -> usize {
         self.0
+    }
+}
+
+impl<'lt, T: Layout> Layout for &'lt T {
+    fn byte_len(&self) -> usize {
+        (**self).byte_len()
+    }
+}
+
+impl<'lt, T: Layout> Layout for &'lt mut T {
+    fn byte_len(&self) -> usize {
+        (**self).byte_len()
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -6,8 +6,6 @@ use core::{alloc, cmp};
 
 mod matrix;
 
-pub use crate::matrix::Layout as MatrixTexels;
-
 /// A byte layout that only describes the user bytes.
 ///
 /// This is a minimal implementation of the basic `Layout` trait. It does not provide any
@@ -248,22 +246,23 @@ pub struct Matrix {
     pub(crate) second_dim: usize,
 }
 
+/// Describes the memory region used for the image.
+///
+/// The underlying buffer may have more data allocated than this region and cause the overhead to
+/// be reused when resizing the image. All ways to construct this already check that all pixels
+/// within the resulting image can be addressed via an index.
+pub struct MatrixTexels<P> {
+    pub(crate) width: usize,
+    pub(crate) height: usize,
+    pub(crate) pixel: Texel<P>,
+}
+
 /// Planar chroma 2×2 block-wise sub-sampled image.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Yuv420p {
     channel: TexelLayout,
     width: u32,
     height: u32,
-}
-
-/// A typed matrix of packed pixels (channel groups).
-///
-/// This is a strongly-typed equivalent to [`Matrix`]. See it for details.
-#[derive(Debug, PartialEq, Eq, Hash)]
-pub struct TMatrix<P> {
-    pixel: Texel<P>,
-    first_dim: usize,
-    second_dim: usize,
 }
 
 /// An error indicating that mending failed due to mismatching pixel attributes.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -530,11 +530,11 @@ impl<L: Layout> Decay<L> for Box<L> {
 /// example, the following comparison all hold:
 ///
 /// ```
-/// # use canvas::pixels::{U8, U16};
+/// # use canvas::texels::{U8, U16};
 /// # use canvas::layout::TexelLayout;
 /// let u8 = TexelLayout::from(U8);
-/// let u8x2 = TexelLayout::from(U8.array2());
-/// let u8x3 = TexelLayout::from(U8.array3());
+/// let u8x2 = TexelLayout::from(U8.array::<2>());
+/// let u8x3 = TexelLayout::from(U8.array::<3>());
 /// let u16 = TexelLayout::from(U16);
 ///
 /// assert!(u8 < u16, "due to size and alignment");

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,5 +1,5 @@
 //! A module for different pixel layouts.
-use crate::pixel::MaxAligned;
+use crate::texel::MaxAligned;
 use crate::{AsTexel, Texel};
 use ::alloc::boxed::Box;
 use core::{alloc, cmp};
@@ -284,7 +284,7 @@ impl Bytes {
 impl TexelLayout {
     /// Construct an element from a self-evident pixel.
     pub fn from_pixel<P: AsTexel>() -> Self {
-        let pix = P::pixel();
+        let pix = P::texel();
         TexelLayout {
             size: pix.size(),
             align: pix.align(),
@@ -308,7 +308,7 @@ impl TexelLayout {
     /// skips the check that such a type must not contain any padding and only performs the layout
     /// related checks.
     pub fn with_layout(layout: alloc::Layout) -> Option<Self> {
-        if layout.align() > MaxAligned::pixel().align() {
+        if layout.align() > MaxAligned::texel().align() {
             return None;
         }
 

--- a/src/layout/matrix.rs
+++ b/src/layout/matrix.rs
@@ -1,0 +1,1 @@
+//! Different styles of matrices.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ mod texel;
 
 pub use self::canvas::Canvas;
 pub use self::matrix::{Matrix, MatrixReuseError};
-pub use self::rec::{Rec, ReuseError};
+pub use self::rec::{BufferReuseError, TexelBuffer};
 pub use self::texel::{AsTexel, Texel};
 
 /// Constants for predefined texel types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,22 @@
 //!
 //! An image canvas compatible with transmuting its byte content.
 //!
+//! This library is strictly `no_std`, and aims to offer utilities to represent and share image
+//! buffers between platforms, byte representations, and processing methods. It acknowledges that,
+//! in a typical image pipeline, there may exist many valid but competing representations:
+//!
+//! - A reader that decodes pixel representations into bytes (in network endian).
+//! - Some other decoder that returns `Vec<[[u16; 3]]>` of native endian data.
+//! - Some library transformation that consumes `&[Rgb<u16>]`.
+//! - Some SIMD usage that requires data is passed as `&[Simd<u16, 16>]`.
+//! - Some GPU buffer written by a highly-aligned, and line-padded `&[u8]`.
+//! - Some GPU buffer containing texels of 4×2 pixels each.
+//! - A *shared* buffer that represents pixels as `&[[AtomicU8; 4]]`.
+//! - A non-planar layout that splits channels to different pages.
+//!
+//! This crate offers the language to ensure that as many uses cases as possible can share
+//! allocations, or even offer zero-copy conversion.
+//!
 //! ## Usage
 //!
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! ```
 // Be std for doctests, avoids a weird warning about missing allocator.
 #![cfg_attr(not(doctest), no_std)]
-// The only module allowed to be `unsafe` is `pixel`. We need it however, as we have a custom
+// The only module allowed to be `unsafe` is `texel`. We need it however, as we have a custom
 // dynamically sized type with an unsafe alignment invariant.
 #![deny(unsafe_code)]
 extern crate alloc;
@@ -39,18 +39,18 @@ mod buf;
 mod canvas;
 pub mod layout;
 mod matrix;
-mod pixel;
 mod rec;
 pub mod stride;
+mod texel;
 
 pub use self::canvas::Canvas;
 pub use self::matrix::{Layout, Matrix, MatrixReuseError};
-pub use self::pixel::{AsTexel, Texel};
 pub use self::rec::{Rec, ReuseError};
+pub use self::texel::{AsTexel, Texel};
 
-/// Constants for predefined pixel types.
-pub mod pixels {
-    pub use crate::pixel::constants::*;
-    pub use crate::pixel::IsTransparentWrapper;
-    pub use crate::pixel::MaxAligned;
+/// Constants for predefined texel types.
+pub mod texels {
+    pub use crate::texel::constants::*;
+    pub use crate::texel::IsTransparentWrapper;
+    pub use crate::texel::MaxAligned;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ extern crate alloc;
 
 mod buf;
 mod canvas;
-pub mod drm;
 pub mod layout;
 mod matrix;
 mod pixel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! ```
 //! # fn send_over_network(_: &[u8]) { };
 //! use canvas::Matrix;
-//! let mut canvas = Matrix::with_width_and_height(400, 400);
+//! let mut canvas = Matrix::<[u8; 4]>::with_width_and_height(400, 400);
 //!
 //! // Draw a bright red line.
 //! for i in 0..400 {
@@ -52,7 +52,7 @@
 extern crate alloc;
 
 mod buf;
-mod canvas;
+pub mod canvas;
 pub mod layout;
 mod matrix;
 mod rec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub mod stride;
 mod texel;
 
 pub use self::canvas::Canvas;
-pub use self::matrix::{Layout, Matrix, MatrixReuseError};
+pub use self::matrix::{Matrix, MatrixReuseError};
 pub use self::rec::{Rec, ReuseError};
 pub use self::texel::{AsTexel, Texel};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub mod stride;
 
 pub use self::canvas::Canvas;
 pub use self::matrix::{Layout, Matrix, MatrixReuseError};
-pub use self::pixel::{AsPixel, Pixel};
+pub use self::pixel::{AsTexel, Texel};
 pub use self::rec::{Rec, ReuseError};
 
 /// Constants for predefined pixel types.

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -73,11 +73,11 @@ pub struct Matrix<P> {
 /// which does not require the interpretation as a full image.
 ///
 /// ```
-/// # use canvas::{Matrix, Layout, TexelBuffer};
+/// # use canvas::{Matrix, layout::MatrixTexels, TexelBuffer};
 /// let buffer = TexelBuffer::<u8>::new(16);
 /// let allocation = buffer.as_bytes().as_ptr();
 ///
-/// let bad_layout = Layout::width_and_height(buffer.capacity() + 1, 1).unwrap();
+/// let bad_layout = MatrixTexels::width_and_height(buffer.capacity() + 1, 1).unwrap();
 /// let error = match Matrix::from_reused_buffer(buffer, bad_layout) {
 ///     Ok(_) => unreachable!("The layout requires one too many pixels"),
 ///     Err(error) => error,
@@ -428,7 +428,12 @@ impl<P> Layout<P> {
     /// Like `std::mem::transmute`, the size of the two types need to be equal. This ensures that
     /// all indices are valid in both directions.
     pub fn transmute_to<Q>(self, pixel: Texel<Q>) -> Layout<Q> {
-        assert!(self.pixel.size() == pixel.size());
+        assert!(
+            self.pixel.size() == pixel.size(),
+            "{} vs {}",
+            self.pixel.size(),
+            pixel.size()
+        );
         Layout {
             width: self.width,
             height: self.height,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -148,7 +148,7 @@ impl<P> Matrix<P> {
     /// # Panics
     /// When allocation of memory fails.
     pub fn with_layout(layout: Layout<P>) -> Self {
-        let rec = Rec::bytes_for_pixel(layout.pixel, layout.byte_len());
+        let rec = Rec::bytes_for_texel(layout.pixel, layout.byte_len());
         Self::new_raw(rec, layout)
     }
 
@@ -242,7 +242,7 @@ impl<P> Matrix<P> {
     ///
     /// See `transmute_to` for details.
     pub fn transmute<Q: AsTexel>(self) -> Matrix<Q> {
-        self.transmute_to(Q::pixel())
+        self.transmute_to(Q::texel())
     }
 
     /// Reinterpret to another, same size pixel type.
@@ -286,7 +286,7 @@ impl<P> Matrix<P> {
         F: Fn(P) -> Q,
         Q: AsTexel,
     {
-        self.map_to(map, Q::pixel())
+        self.map_to(map, Q::texel())
     }
 
     /// Apply a function to all pixel values.
@@ -317,7 +317,7 @@ impl<P> Matrix<P> {
         F: Fn(P) -> Q,
         Q: AsTexel,
     {
-        self.map_reuse_to(map, Q::pixel())
+        self.map_reuse_to(map, Q::texel())
     }
 
     pub fn map_reuse_to<F, Q>(
@@ -371,7 +371,7 @@ impl<P> Layout<P> {
     where
         P: AsTexel,
     {
-        Self::width_and_height_for_pixel(P::pixel(), width, height)
+        Self::width_and_height_for_pixel(P::texel(), width, height)
     }
 
     /// Get the required bytes for this layout.
@@ -401,7 +401,7 @@ impl<P> Layout<P> {
     ///
     /// See `transmute_to` for details.
     pub fn transmute<Q: AsTexel>(self) -> Layout<Q> {
-        self.transmute_to(Q::pixel())
+        self.transmute_to(Q::texel())
     }
 
     /// Reinterpret to another, same size pixel type.
@@ -420,7 +420,7 @@ impl<P> Layout<P> {
 
     /// Utility method to change the pixel type without changing the dimensions.
     pub fn map<Q: AsTexel>(self) -> Option<Layout<Q>> {
-        self.map_to(Q::pixel())
+        self.map_to(Q::texel())
     }
 
     /// Utility method to change the pixel type without changing the dimensions.
@@ -504,7 +504,7 @@ impl<P: AsTexel> Default for Layout<P> {
         Layout {
             width: 0,
             height: 0,
-            pixel: P::pixel(),
+            pixel: P::texel(),
         }
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -6,6 +6,7 @@ use core::{cmp, fmt};
 
 use crate::buf::Buffer;
 use crate::canvas::{Canvas, RawCanvas};
+use crate::layout::MatrixTexels as Layout;
 use crate::{layout, AsTexel, BufferReuseError, Texel, TexelBuffer};
 
 /// A 2d, width-major matrix of pixels.
@@ -60,17 +61,6 @@ use crate::{layout, AsTexel, BufferReuseError, Texel, TexelBuffer};
 #[derive(Clone, PartialEq, Eq)]
 pub struct Matrix<P> {
     inner: RawCanvas<Buffer, Layout<P>>,
-}
-
-/// Describes the memory region used for the image.
-///
-/// The underlying buffer may have more data allocated than this region and cause the overhead to
-/// be reused when resizing the image. All ways to construct this already check that all pixels
-/// within the resulting image can be addressed via an index.
-pub struct Layout<P> {
-    width: usize,
-    height: usize,
-    pixel: Texel<P>,
 }
 
 /// Error representation for a failed buffer reuse for a canvas.

--- a/src/rec.rs
+++ b/src/rec.rs
@@ -248,7 +248,7 @@ impl<P> TexelBuffer<P> {
 
     /// The number of elements that can fit without reallocation.
     pub fn capacity(&self) -> usize {
-        self.inner.capacity() / self.texel.size()
+        self.inner.capacity() / self.texel.size_nz().get()
     }
 
     pub fn as_bytes(&self) -> &[u8] {

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -14,9 +14,9 @@
 //! canvas. They internally contain a simple byte slice which allows viewing any source buffer as a
 //! strided matrix even when it was not allocated with the special allocator.
 use crate::canvas::Canvas;
+use crate::layout;
 use crate::layout::Layout;
 use crate::texel::AsTexel;
-use crate::{layout, matrix};
 use core::ops::Range;
 
 /// A simple layout describing some pixels as a byte matrix.
@@ -407,14 +407,9 @@ impl Strided for StrideLayout {
     }
 }
 
-impl<P: AsTexel> Strided for matrix::Layout<P> {
+impl<P: AsTexel> Strided for layout::MatrixTexels<P> {
     fn strided(&self) -> StrideLayout {
-        let matrix = layout::Matrix::from_width_height(
-            layout::TexelLayout::from_pixel::<P>(),
-            self.width(),
-            self.height(),
-        );
-        let matrix = matrix.expect("Fits into memory");
+        let matrix: layout::Matrix = self.clone().into();
         StrideLayout::with_row_major(matrix)
     }
 }

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -15,7 +15,7 @@
 //! strided matrix even when it was not allocated with the special allocator.
 use crate::canvas::Canvas;
 use crate::layout::Layout;
-use crate::pixel::AsPixel;
+use crate::pixel::AsTexel;
 use crate::{layout, matrix};
 use core::ops::Range;
 
@@ -30,7 +30,7 @@ pub struct StrideSpec {
     ///
     /// If this differs from both `width_stride` and `height_stride` the any copy must loop over
     /// individual pixels. Otherwise, whole rows or columns of contiguous data may be inspected.
-    pub element: layout::Element,
+    pub element: layout::TexelLayout,
     /// The number of bytes to go one pixel along the width.
     pub width_stride: usize,
     /// The number of bytes to go one pixel along the height.
@@ -216,7 +216,7 @@ impl StrideLayout {
     /// Shrink the element's size or alignment.
     ///
     /// This is always valid since the new layout is strictly contained within the old one.
-    pub fn shrink_element(&mut self, new: layout::Element) {
+    pub fn shrink_element(&mut self, new: layout::TexelLayout) {
         self.spec.element = self.spec.element.infimum(new);
     }
 
@@ -267,7 +267,7 @@ impl Strides {
     /// Shrink the element's size or alignment.
     ///
     /// This operation never reallocates the buffer.
-    pub fn shrink_element(&mut self, new: layout::Element) {
+    pub fn shrink_element(&mut self, new: layout::TexelLayout) {
         self.inner.layout_mut_unguarded().shrink_element(new)
     }
 
@@ -309,7 +309,7 @@ impl<'data> ByteCanvasRef<'data> {
     /// Shrink the element's size or alignment.
     ///
     /// This operation never reallocates the buffer.
-    pub fn shrink_element(&mut self, new: layout::Element) {
+    pub fn shrink_element(&mut self, new: layout::TexelLayout) {
         self.layout.shrink_element(new)
     }
 
@@ -333,7 +333,7 @@ impl<'data> ByteCanvasMut<'data> {
     /// Shrink the element's size or alignment.
     ///
     /// This operation never reallocates the buffer.
-    pub fn shrink_element(&mut self, new: layout::Element) {
+    pub fn shrink_element(&mut self, new: layout::TexelLayout) {
         self.layout.shrink_element(new)
     }
 
@@ -407,10 +407,10 @@ impl Strided for StrideLayout {
     }
 }
 
-impl<P: AsPixel> Strided for matrix::Layout<P> {
+impl<P: AsTexel> Strided for matrix::Layout<P> {
     fn strided(&self) -> StrideLayout {
         let matrix = layout::Matrix::from_width_height(
-            layout::Element::from_pixel::<P>(),
+            layout::TexelLayout::from_pixel::<P>(),
             self.width(),
             self.height(),
         );
@@ -428,7 +428,7 @@ impl From<BadStrideKind> for BadStrideError {
 #[test]
 fn align_validation() {
     // Setup a good base specification.
-    let matrix = layout::Matrix::from_width_height(layout::Element::from_pixel::<u16>(), 2, 2)
+    let matrix = layout::Matrix::from_width_height(layout::TexelLayout::from_pixel::<u16>(), 2, 2)
         .expect("Valid matrix");
     let layout = StrideLayout::with_row_major(matrix);
 
@@ -446,7 +446,7 @@ fn align_validation() {
 
 #[test]
 fn canvas_copies() {
-    let matrix = layout::Matrix::from_width_height(layout::Element::from_pixel::<u8>(), 2, 2)
+    let matrix = layout::Matrix::from_width_height(layout::TexelLayout::from_pixel::<u8>(), 2, 2)
         .expect("Valid matrix");
     let row_layout = StrideLayout::with_row_major(matrix);
     let col_layout = StrideLayout::with_column_major(matrix);

--- a/src/stride.rs
+++ b/src/stride.rs
@@ -15,7 +15,7 @@
 //! strided matrix even when it was not allocated with the special allocator.
 use crate::canvas::Canvas;
 use crate::layout::Layout;
-use crate::pixel::AsTexel;
+use crate::texel::AsTexel;
 use crate::{layout, matrix};
 use core::ops::Range;
 

--- a/src/texel.rs
+++ b/src/texel.rs
@@ -151,7 +151,13 @@ impl<P> Texel<P> {
     /// * have any validity invariants, i.e. is mustn't contain any padding.
     /// * have any safety invariants. This implies it can be copied.
     /// * have an alignment larger than [`MaxAligned`].
-    /// * have a non-zero size.
+    /// * be a zero-size type.
+    ///
+    /// Furthermore, tentatively, the type must not have any drop glue. That is its members are all
+    /// simple types without Drop implementations. This requirement exists mainly to avoid code
+    /// accidentally leaking instances, and ensures that copies created from their byte
+    /// representation—which is safe according to the other invairants— do not cause unexpected
+    /// effects.
     ///
     /// [`MaxAligned`]: struct.MaxAligned.html
     pub const unsafe fn new_unchecked() -> Self {

--- a/src/texel.rs
+++ b/src/texel.rs
@@ -88,6 +88,30 @@ pub(crate) mod constants {
         (F64, f64),
         (MAX, MaxAligned)
     );
+
+    impl<T: AsTexel> AsTexel for [T; 1] {
+        fn texel() -> Texel<[T; 1]> {
+            T::texel().array::<1>()
+        }
+    }
+
+    impl<T: AsTexel> AsTexel for [T; 2] {
+        fn texel() -> Texel<[T; 2]> {
+            T::texel().array::<2>()
+        }
+    }
+
+    impl<T: AsTexel> AsTexel for [T; 3] {
+        fn texel() -> Texel<[T; 3]> {
+            T::texel().array::<3>()
+        }
+    }
+
+    impl<T: AsTexel> AsTexel for [T; 4] {
+        fn texel() -> Texel<[T; 4]> {
+            T::texel().array::<4>()
+        }
+    }
 }
 
 impl<P: bytemuck::Pod> Texel<P> {


### PR DESCRIPTION
- The `drm` module moved to a separate crate
- Made sure the `Canvas`/`CanvasRef`/`CanvasMut` interface is more consistent
- Rename `Pixel` to `Texel` etc.
- Require that a `Texel` is non-zero-sized, less complexity in implementation for now