### PR TITLE
Shared image

### DIFF
--- a/texel/src/arc.rs
+++ b/texel/src/arc.rs
@@ -1,0 +1,6 @@
+
+
+#[derive(Clone, Default)]
+pub(crate) struct ArcBuffer {
+    inner: Arc<[AlignedAtomic]>,
+}

--- a/texel/src/buf.rs
+++ b/texel/src/buf.rs
@@ -498,6 +498,18 @@ impl From<&'_ [u8]> for Buffer {
     }
 }
 
+impl From<&'_ [u8]> for AtomicBuffer {
+    fn from(_: &'_ [u8]) -> Self {
+        todo!()
+    }
+}
+
+impl From<&'_ [u8]> for CellBuffer {
+    fn from(_: &'_ [u8]) -> Self {
+        todo!()
+    }
+}
+
 impl From<&'_ buf> for Buffer {
     fn from(content: &'_ buf) -> Self {
         content.to_owned()
@@ -648,6 +660,70 @@ impl ops::Index<ops::RangeTo<usize>> for buf {
 impl ops::IndexMut<ops::RangeTo<usize>> for buf {
     fn index_mut(&mut self, idx: ops::RangeTo<usize>) -> &mut buf {
         self.truncate_mut(idx.end)
+    }
+}
+
+#[allow(dead_code)]
+impl atomic_buf {
+    /// Overwrite bytes within the vector with new data.
+    fn copy_within(&self, _from: core::ops::Range<usize>, _to: usize) {
+        todo!()
+    }
+
+    /// Overwrite the whole vector with new data.
+    fn copy_from(
+        &self,
+        _from: core::ops::Range<usize>,
+        _source: &[MaxAtomic],
+        _to: usize,
+    ) {
+        todo!()
+    }
+}
+
+impl cell_buf {
+    /// Wraps an aligned buffer into `buf`.
+    ///
+    /// This method will never panic, as the alignment of the data is guaranteed.
+    pub fn new<T>(_data: &T) -> &Self
+    where
+        T: AsRef<[MaxCell]> + ?Sized,
+    {
+        // We can't use `bytemuck` here.
+        todo!()
+    }
+
+    pub fn truncate(&self, at: usize) -> &Self {
+        // We promise this does not panic since the buffer is in fact aligned.
+        Self::from_bytes(&self.0.as_slice_of_cells()[..at]).unwrap()
+    }
+
+    pub fn split_at(&self, at: usize) -> (&Self, &Self) {
+        assert!(at % MAX_ALIGN == 0);
+        let (a, b) = self.0.as_slice_of_cells().split_at(at);
+        let a = Self::from_bytes(a).expect("was previously aligned");
+        let b = Self::from_bytes(b).expect("asserted to be aligned");
+        (a, b)
+    }
+
+    /// Reinterpret the buffer for the specific texel type.
+    ///
+    /// The alignment of `P` is already checked to be smaller than `MAX_ALIGN` through the
+    /// constructor of `Texel`. The slice will have the maximum length possible but may leave
+    /// unused bytes in the end.
+    pub fn as_texels<P>(&self, _pixel: Texel<P>) -> &cell::Cell<[P]> {
+        todo!()
+    }
+
+    pub fn map_within<P, Q>(
+        &mut self,
+        _src: impl ops::RangeBounds<usize>,
+        _dest: usize,
+        _f: impl Fn(P) -> Q,
+        _p: Texel<P>,
+        _q: Texel<Q>,
+    ) {
+        todo!()
     }
 }
 

--- a/texel/src/buf.rs
+++ b/texel/src/buf.rs
@@ -6,7 +6,7 @@ use core::{borrow, cmp, mem, ops};
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
-use crate::texel::{constants::MAX, MaxAligned, Texel, MAX_ALIGN};
+use crate::texel::{constants::MAX, AtomicPart, MaxAligned, MaxAtomic, Texel, MAX_ALIGN};
 
 /// Allocates and manages raw bytes.
 ///
@@ -36,6 +36,18 @@ pub(crate) struct Buffer {
 #[repr(transparent)]
 #[allow(non_camel_case_types)]
 pub(crate) struct buf([u8]);
+
+/// An aligned slice of atomic memory.
+///
+/// This is a wrapper around a byte slice that additionally requires the slice to be highly
+/// aligned. It's usually created by first allocating an owned `buf`, and sharing it.
+///
+/// Note: Contrary to `buf`, this type __can not__ be sliced at arbitrary locations.
+///
+/// See `pixel.rs` for the only constructors.
+#[repr(transparent)]
+#[allow(non_camel_case_types)]
+pub(crate) struct atomic_buf([AtomicPart]);
 
 /// A copy-on-grow version of a buffer.
 pub(crate) enum Cog<'buf> {

--- a/texel/src/buf.rs
+++ b/texel/src/buf.rs
@@ -4,6 +4,7 @@
 use core::{borrow, cell, cmp, mem, ops, sync::atomic};
 
 use alloc::borrow::ToOwned;
+use alloc::rc::Rc;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
@@ -63,7 +64,7 @@ pub struct AtomicBuffer {
 #[derive(Clone)]
 pub struct CellBuffer {
     /// The backing memory, aligned by allocating it with the proper type.
-    inner: Arc<[MaxCell]>,
+    inner: Rc<[MaxCell]>,
 }
 
 /// An aligned slice of memory.

--- a/texel/src/lib.rs
+++ b/texel/src/lib.rs
@@ -105,4 +105,5 @@ pub mod texels {
     pub use crate::texel::constants::*;
     pub use crate::texel::IsTransparentWrapper;
     pub use crate::texel::MaxAligned;
+    pub use crate::texel::MaxAtomic;
 }

--- a/texel/src/lib.rs
+++ b/texel/src/lib.rs
@@ -108,5 +108,5 @@ pub mod texels {
     pub use crate::texel::MaxAtomic;
     pub use crate::texel::MaxCell;
 
-    pub use crate::buf::{buf, cell_buf, Buffer, CellBuffer};
+    pub use crate::buf::{atomic_buf, buf, cell_buf, AtomicBuffer, Buffer, CellBuffer};
 }

--- a/texel/src/lib.rs
+++ b/texel/src/lib.rs
@@ -106,4 +106,7 @@ pub mod texels {
     pub use crate::texel::IsTransparentWrapper;
     pub use crate::texel::MaxAligned;
     pub use crate::texel::MaxAtomic;
+    pub use crate::texel::MaxCell;
+
+    pub use crate::buf::{buf, cell_buf, Buffer, CellBuffer};
 }

--- a/texel/src/rec.rs
+++ b/texel/src/rec.rs
@@ -114,7 +114,7 @@ impl<P> TexelBuffer<P> {
     ///
     /// This function will panic if the allocation fails.
     pub fn with_elements_for_texel(texel: Texel<P>, elements: &[P]) -> Self {
-        let src = texel.cast_bytes(elements);
+        let src = texel.to_bytes(elements);
         let mut buffer = TexelBuffer::from_buffer(Buffer::from(src), texel);
         // Will be treated as empty, so adjust to be filled up to count.
         buffer.length = src.len();

--- a/texel/src/rec.rs
+++ b/texel/src/rec.rs
@@ -247,10 +247,12 @@ impl<P> TexelBuffer<P> {
         self.length = exact_size;
     }
 
+    /// View the valid portion of the buffer as a slice of the texel type.
     pub fn as_slice(&self) -> &[P] {
         self.buf().as_texels(self.texel)
     }
 
+    /// View the valid portion of the buffer as a mutable slice of the texel type.
     pub fn as_mut_slice(&mut self) -> &mut [P] {
         let texel = self.texel;
         self.buf_mut().as_mut_texels(texel)
@@ -266,10 +268,12 @@ impl<P> TexelBuffer<P> {
         self.inner.capacity() / self.texel.size_nz().get()
     }
 
+    /// View the raw bytes representing the buffer, in the native memory layout.
     pub fn as_bytes(&self) -> &[u8] {
         self.buf().as_bytes()
     }
 
+    /// View the mutable raw bytes representing the buffer, in the native memory layout.
     pub fn as_bytes_mut(&mut self) -> &mut [u8] {
         self.buf_mut().as_bytes_mut()
     }

--- a/texel/src/texel.rs
+++ b/texel/src/texel.rs
@@ -115,6 +115,7 @@ macro_rules! def_max_align {
                 repr(align($num))
             )]
         )*
+        $(#[$atomic_attr])*
         pub struct MaxAtomic(pub(crate) [AtomicPart; ATOMIC_PARTS]);
 
         $(
@@ -123,6 +124,7 @@ macro_rules! def_max_align {
                 repr(align($num))
             )]
         )*
+        $(#[$cell_attr])*
         pub struct MaxCell(pub(crate) Cell<[u8; MAX_ALIGN]>);
 
         $(
@@ -701,6 +703,33 @@ impl MaxAtomic {
         }
 
         result
+    }
+}
+
+impl MaxCell {
+    /// Create a vector of atomic zero-bytes.
+    pub const fn zero() -> Self {
+        MaxCell(Cell::new([0; MAX_ALIGN]))
+    }
+
+    /// Create a vector from values initialized synchronously.
+    pub fn new(contents: MaxAligned) -> Self {
+        MaxCell(Cell::new(contents.0))
+    }
+
+    /// Overwrite the contents with new information from another cell.
+    pub fn set(&self, newval: &Self) {
+        self.0.set(newval.0.get())
+    }
+
+    /// Read the current contents from this cell into an owned value.
+    pub fn get(&self) -> MaxAligned {
+        MaxAligned(self.0.get())
+    }
+
+    /// Unwrap an owned value.
+    pub fn into_inner(self) -> MaxAligned {
+        MaxAligned(self.0.into_inner())
     }
 }
 

--- a/texel/src/texel.rs
+++ b/texel/src/texel.rs
@@ -8,7 +8,6 @@ use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use core::marker::PhantomData;
 use core::{fmt, hash, mem, num, ptr, slice};
 
-use alloc::sync::Arc;
 use crate::buf::{buf, atomic_buf, cell_buf};
 
 /// Marker struct to denote a texel type.

--- a/texel/tests/atomic.rs
+++ b/texel/tests/atomic.rs
@@ -1,0 +1,53 @@
+use image_texel::texels::{AtomicBuffer, U32};
+use std::{mem, thread};
+
+#[test]
+fn mapping_atomics_parallel() {
+    const LEN: usize = 128;
+    let buffer = AtomicBuffer::new(LEN * mem::size_of::<u32>());
+    // And receive all the results in this shared copy of our buffer.
+    let output_tap = buffer.clone();
+
+    const SPLIT_MAX: usize = 1 << 6;
+    // Proxy for whether we run with optimization. Makes execution time bearable.
+    #[cfg(debug_assertions)]
+    const REPEAT: usize = 1 << 6;
+    #[cfg(not(debug_assertions))]
+    const REPEAT: usize = 1 << 12;
+
+    for split in 0..SPLIT_MAX {
+        // We want the modifying loops to overlap as much as possible for the strongest test, so
+        // ensure they do not run early.
+        let barrier = &std::sync::Barrier::new(2);
+
+        // Concurrently and repeatedly increment non-overlapping parts of the image.
+        thread::scope(|join| {
+            let img_a = buffer.clone();
+            let img_b = buffer.clone();
+
+            join.spawn(move || {
+                let _ = barrier.wait();
+                for _ in 0..REPEAT {
+                    img_a.map_within(..split, 0, |n: u32| n + 1, U32, U32);
+                }
+            });
+
+            join.spawn(move || {
+                let _ = barrier.wait();
+                for _ in 0..REPEAT {
+                    img_b.map_within(split.., split, |n: u32| n + 1, U32, U32);
+                }
+            });
+        });
+    }
+
+    // Each individual `u32` has been incremented precisely as often as each other. Since the
+    // individual transforms are synchronized with thread-scope and within they do not overlap with
+    // each other, we must expect that the values have each been touched precisely how we intended
+    // them to.
+    let expected = (SPLIT_MAX * REPEAT) as u32;
+    assert_eq!(
+        output_tap.to_owned().as_texels(U32)[..LEN].to_vec(),
+        (0..LEN as u32).map(|_| expected).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Implementing two new buffers in `texel` which interact through the existing `Texel` type:

* `CellBuffer`, keeping its data in a shared `Rc` and supporting concurrent modification.
* `AtomicBuffer`, keeping its data in a shared `Arc` and supporting parallel modification in a manner that is potentially wait-free if the underlying platform primitives allow it. The effect of modifications is only specified if the user avoids aliasing but it is *always sound*.

Unfortunately the `Image` and derived layout-imbued buffers heavily depend on `as_slice() -> &[P]` which neither of these new types can provide. Even `RawImage`, the underlying private primitive, depends on traits that offer these methods as all byte-access is done through a direct byte slice for efficiency. Since I don't have a concrete idea on how to best approach this conflict, let's just put that for another time. This also includes lifting the types in `canvas` where it could be used for the shader / conversion code.