### PR TITLE
Fix texel coordinate assignment

### DIFF
--- a/canvas/src/layout.rs
+++ b/canvas/src/layout.rs
@@ -848,6 +848,8 @@ impl CanvasLayout {
         iter: &[[u32; 2]],
         chunk: ChunkSpec,
     ) {
+        debug_assert_eq!(idx.len(), iter.len());
+
         if self.texel.bits.bytes() == 0 {
             unreachable!("No texel with zero bytes");
         }
@@ -873,6 +875,8 @@ impl CanvasLayout {
         pitch: u32,
         spec: ChunkSpec,
     ) {
+        debug_assert_eq!(iter.len(), idx.len());
+
         let pitch = u64::from(pitch);
         let mut index_chunks = idx.chunks_mut(spec.chunk_size);
         let mut iter = iter.chunks(spec.chunk_size);


### PR DESCRIPTION
In operations with mismatching texel blocks, i.e. when compressing from a pixel texel into a packed form or exploding a packed form, the index generation would only run on 1024—the default chunk size—input and output texels at a time resulting in some fetch/write coordinates being corrupted to the 0th texel instead.

More specifically, it would always run on at most the chunk size texels but when mismatched texels are being used that is the count of super blocks. There are more reads and write happening. Each individually is stacked into a 'super block' that is the least common multiple along each individual axis. For instance, packing pixels into a 1x8 binary bit texture would use 8 input texels, one output texel, for each such super block which is 8 pixels wide. This would result in everything except the first eighth of each super block, which are 8*1024 input pixels (across rows), being wrongly filled with information from the 0th texel in the upper left corner effectively duplicating that single pixels color information *a lot* in images larger than 1024 pixels.