### PR TITLE
Data transfer utilities

### DIFF
--- a/canvas/src/frame.rs
+++ b/canvas/src/frame.rs
@@ -272,7 +272,7 @@ impl Canvas {
 
         let mut offset = 0;
         // This frame's layout takes 0 bytes, so we can take all contents with split_layout
-        let frame: ImageMut<'_, Bytes> = self.as_mut().decay().expect("decay to bytes valid");
+        let frame: ImageMut<'_, Bytes> = self.as_mut().decay();
 
         let &Bytes(total_len) = frame.layout();
         let mut frame = frame.with_layout(Bytes(0)).expect("zero-byte layout valid");
@@ -444,7 +444,7 @@ impl<'data, C> ChannelsMut<'data, C> {
 impl<'data, T> From<PlaneRef<'data, T>> for BytePlaneRef<'data> {
     fn from(plane: PlaneRef<'data, T>) -> Self {
         BytePlaneRef {
-            inner: plane.inner.decay().unwrap(),
+            inner: plane.inner.decay(),
         }
     }
 }
@@ -452,7 +452,7 @@ impl<'data, T> From<PlaneRef<'data, T>> for BytePlaneRef<'data> {
 impl<'data, T> From<PlaneMut<'data, T>> for BytePlaneMut<'data> {
     fn from(plane: PlaneMut<'data, T>) -> Self {
         BytePlaneMut {
-            inner: plane.inner.decay().unwrap(),
+            inner: plane.inner.decay(),
         }
     }
 }

--- a/texel/src/buf.rs
+++ b/texel/src/buf.rs
@@ -1712,7 +1712,6 @@ mod tests {
         let buffer = AtomicBuffer::with_buffer(initial_state);
         // And receive all the results in this shared copy of our buffer.
         let output_tap = buffer.clone();
-        // assert!(buffer.ptr_eq(&output_tap));
 
         // Map those numbers in-place.
         buffer.map_within(..LEN, 0, |n: u32| n as u8, U32, U8);

--- a/texel/src/buf.rs
+++ b/texel/src/buf.rs
@@ -1996,7 +1996,10 @@ mod tests {
                 n
             });
 
-            let target = atomic.as_texels(U16).index(offset..).index(..3 * MAX_ALIGN / 2);
+            let target = atomic
+                .as_texels(U16)
+                .index(offset..)
+                .index(..3 * MAX_ALIGN / 2);
             U16.store_atomic_slice(target, &data[..]);
 
             let mut check = [0; 3 * MAX_ALIGN / 2];

--- a/texel/src/image.rs
+++ b/texel/src/image.rs
@@ -50,7 +50,8 @@ pub use cell::{CellImage, CellImageRef};
 ///
 /// Initialize a matrix as computed `[u8; 4]` rga pixels:
 ///
-/// ```
+#[cfg_attr(not(miri), doc = "```")]
+#[cfg_attr(miri, doc = "```no_run")] // too expensive and pointless
 /// # fn test() -> Option<()> {
 /// use image_texel::{Image, Matrix};
 ///

--- a/texel/src/image/atomic.rs
+++ b/texel/src/image/atomic.rs
@@ -5,7 +5,7 @@ use crate::buf::{atomic_buf, AtomicBuffer, AtomicSliceRef};
 use crate::image::{raw::RawImage, IntoPlanesError};
 use crate::layout::{Bytes, Decay, Layout, Mend, PlaneOf, Relocate, SliceLayout, Take, TryMend};
 use crate::texel::{constants::U8, MAX_ALIGN};
-use crate::{Texel, TexelBuffer};
+use crate::{BufferReuseError, Texel, TexelBuffer};
 
 /// A container of allocated bytes, parameterized over the layout.
 ///
@@ -75,6 +75,19 @@ impl<L: Layout> AtomicImage<L> {
             .try_reinterpret(layout)
             .map(Into::into)
             .map_err(Into::into)
+    }
+
+    /// Attempt to modify the layout to a new value, without modifying its type.
+    ///
+    /// Returns an `Err` if the layout does not fit the underlying buffer. Otherwise returns `Ok`
+    /// and overwrites the layout accordingly.
+    ///
+    /// TODO: public name and provide a `set_capacity` for `L = Bytes`?
+    pub(crate) fn try_set_layout(&mut self, layout: L) -> Result<(), BufferReuseError>
+    where
+        L: Layout,
+    {
+        self.inner.try_reuse(layout)
     }
 
     /// Decay into a image with less specific layout.
@@ -385,6 +398,19 @@ impl<'data, L> AtomicImageRef<'data, L> {
         M: Layout,
     {
         Some(self.inner.try_reinterpret(layout).ok()?.into())
+    }
+
+    /// Attempt to modify the layout to a new value, without modifying its type.
+    ///
+    /// Returns an `Err` if the layout does not fit the underlying buffer. Otherwise returns `Ok`
+    /// and overwrites the layout accordingly.
+    ///
+    /// TODO: public name and provide a `set_capacity` for `L = Bytes`?
+    pub(crate) fn try_set_layout(&mut self, layout: L) -> Result<(), BufferReuseError>
+    where
+        L: Layout,
+    {
+        self.inner.try_reuse(layout)
     }
 
     /// Decay into a image with less specific layout.

--- a/texel/src/image/atomic.rs
+++ b/texel/src/image/atomic.rs
@@ -322,6 +322,11 @@ impl<L> AtomicImage<L> {
 }
 
 impl<'data, L> AtomicImageRef<'data, L> {
+    /// Get a reference to the complete underlying buffer, ignoring the layout.
+    pub fn as_capacity_atomic_buf(&self) -> &atomic_buf {
+        self.inner.get()
+    }
+
     pub fn layout(&self) -> &L {
         self.inner.layout()
     }

--- a/texel/src/image/atomic.rs
+++ b/texel/src/image/atomic.rs
@@ -112,6 +112,19 @@ impl<L: Layout> AtomicImage<L> {
     /// ```
     ///
     /// [`Decay`]: ../layout/trait.Decay.html
+    pub fn decay<M>(self) -> AtomicImage<M>
+    where
+        M: Decay<L>,
+        M: Layout,
+    {
+        self.inner
+            .checked_decay()
+            .unwrap_or_else(super::decay_failed)
+            .into()
+    }
+
+    /// Like [`Self::decay`]` but returns `None` rather than panicking. While this is strictly
+    /// speaking a violation of the trait contract, you may want to handle this yourself.
     pub fn checked_decay<M>(self) -> Option<AtomicImage<M>>
     where
         M: Decay<L>,
@@ -372,6 +385,20 @@ impl<'data, L> AtomicImageRef<'data, L> {
         M: Layout,
     {
         Some(self.inner.try_reinterpret(layout).ok()?.into())
+    }
+
+    /// Decay into a image with less specific layout.
+    ///
+    /// See [`AtomicImage::decay`].
+    pub fn decay<M>(self) -> AtomicImageRef<'data, M>
+    where
+        M: Decay<L>,
+        M: Layout,
+    {
+        self.inner
+            .checked_decay()
+            .unwrap_or_else(super::decay_failed)
+            .into()
     }
 
     /// Decay into a image with less specific layout.

--- a/texel/src/image/cell.rs
+++ b/texel/src/image/cell.rs
@@ -297,6 +297,19 @@ impl<L> CellImage<L> {
 }
 
 impl<'data, L> CellImageRef<'data, L> {
+    /// Get a reference to the underlying buffer.
+    pub fn as_cell_buf(&self) -> &cell_buf
+    where
+        L: Layout,
+    {
+        self.inner.as_cell_buf()
+    }
+
+    /// Get a reference to the complete underlying buffer, ignoring the layout.
+    pub fn as_capacity_cell_buf(&self) -> &cell_buf {
+        self.inner.get()
+    }
+
     pub fn layout(&self) -> &L {
         self.inner.layout()
     }

--- a/texel/src/image/unaligned.rs
+++ b/texel/src/image/unaligned.rs
@@ -1,0 +1,146 @@
+//! Buffers that can work with unaligned underlying data.
+//!
+//! These are mostly for IO purposes since most compute algorithms are not expected to support
+//! interactions with these buffers. However, these buffers support more generalized layouts with
+//! the goal of admitting a description of arbitrary external resources. In consequence, these
+//! buffers interact by references only.
+use core::cell::Cell;
+
+use crate::buf::buf;
+use crate::image::{
+    AtomicImage, AtomicImageRef, CellImage, CellImageRef, Image, ImageMut, ImageRef,
+};
+use crate::layout::{Bytes, Layout};
+
+pub struct DataRef<'lt, Layout = Bytes> {
+    data: &'lt [u8],
+    layout: Layout,
+}
+
+pub struct DataMut<'lt, Layout = Bytes> {
+    data: &'lt mut [u8],
+    layout: Layout,
+}
+
+pub struct DataCells<'lt, Layout = Bytes> {
+    data: &'lt [Cell<u8>],
+    layout: Layout,
+}
+
+macro_rules! transfer_methods {
+    (
+        derive {
+            $(write_to_buf: $write_to_buf:path,)?
+            $(read_from_buf: $read_from_buf:path,)?
+        }
+    ) => {
+        $(
+            /// Write to an image, changing the layout in the process.
+            ///
+            /// See [`Self::write_to_image`] but works on a borrowed buffer, only when it has the same
+            /// layout type. Clones the layout to the image buffer.
+            ///
+            /// Reallocates the image buffer when necessary to ensure that the allocated buffer fits the
+            /// new data's layout.
+            ///
+            /// Consider [`Self::write_to_buf`] with the [`Image::as_capacity_buf_mut`] when you want to
+            /// ignore the layout value of the target buffer.
+            pub fn write_to(&self, buffer: &mut Image<L>)
+            where
+                L: Clone + Layout,
+            {
+                buffer.layout_mut_unguarded().clone_from(&self.layout);
+                buffer.ensure_layout();
+                $write_to_buf(self, buffer.as_capacity_buf_mut());
+            }
+
+            /// Write to an image, changing the layout in the process.
+            ///
+            /// Reallocates the image buffer when necessary to ensure that the allocated buffer fits the
+            /// new data's layout.
+            pub fn write_to_image(&self, buffer: Image<impl Layout>) -> Image<L>
+            where
+                L: Clone + Layout,
+            {
+                let mut buffer = buffer.with_layout(self.layout.clone());
+                $write_to_buf(self, buffer.as_capacity_buf_mut());
+                buffer
+            }
+
+            /// Write to a mutable borrowed buffer with layout.
+            ///
+            /// First verifies that the data will fit into the target. Then returns `Some` with a new
+            /// reference to the target buffer that is using the data's layout. Otherwise, returns `None`.
+            pub fn write_to_mut<'data>(
+                &self,
+                buffer: ImageMut<'data, impl Layout>,
+            ) -> Option<ImageMut<'data, L>>
+            where
+                L: Clone + Layout,
+            {
+                let mut buffer = buffer.with_layout(self.layout.clone())?;
+                $write_to_buf(self, buffer.as_mut_buf());
+                Some(buffer)
+            }
+        )* /*write_to_buf */
+    }
+}
+
+impl<'lt, L> DataRef<'lt, L> {
+    /// Verifies the data against the layout before construction.
+    ///
+    /// Note that the type has no hard invariants.
+    pub fn checked_new(data: &'lt [u8], layout: L) -> Option<Self>
+    where
+        L: Layout,
+    {
+        Some(data)
+            .filter(|data| <dyn Layout>::fits_data(&layout, data))
+            .map(|data| DataRef { data, layout })
+    }
+
+    /// Copy the data bytes of the layout to the byte buffer.
+    pub fn write_to_buf<'data>(&self, buffer: &mut buf) {
+        let len = buffer.len().min(core::mem::size_of_val(self.data));
+        buffer[..len].copy_from_slice(self.data);
+    }
+
+    transfer_methods! {
+        derive {
+            write_to_buf: Self::write_to_buf,
+        }
+    }
+}
+
+impl<'lt, L> DataMut<'lt, L> {
+    /// Verifies the data against the layout before construction.
+    ///
+    /// Note that the type has no hard invariants.
+    pub fn checked_new(data: &'lt mut [u8], layout: L) -> Option<Self>
+    where
+        L: Layout,
+    {
+        Some(data)
+            .filter(|data| <dyn Layout>::fits_data(&layout, data))
+            .map(|data| DataMut { data, layout })
+    }
+
+    /// Copy the data bytes of the layout to the byte buffer.
+    pub fn write_to_buf(&self, buffer: &mut buf) {
+        let len = buffer.len().min(core::mem::size_of_val(self.data));
+        buffer[..len].copy_from_slice(self.data);
+    }
+
+    /// Copy the data bytes of the layout to the byte buffer.
+    pub fn read_from_buf(&mut self, buffer: &buf) {
+        let len = buffer.len().min(core::mem::size_of_val(self.data));
+        self.data[..len].copy_from_slice(buffer);
+    }
+
+    transfer_methods! {
+        derive {
+            write_to_buf: Self::write_to_buf,
+            read_from_buf: Self::read_from_buf,
+        }
+    }
+}

--- a/texel/src/image/unaligned.rs
+++ b/texel/src/image/unaligned.rs
@@ -4,85 +4,116 @@
 //! interactions with these buffers. However, these buffers support more generalized layouts with
 //! the goal of admitting a description of arbitrary external resources. In consequence, these
 //! buffers interact by references only.
-use core::cell::Cell;
+mod sealed {
+    use crate::buf::{atomic_buf, buf, cell_buf};
+    use crate::layout::Layout;
+    use core::ops::Range;
 
-use crate::buf::buf;
+    pub trait LayoutEngineCore {
+        type Layout: Layout;
+
+        fn layout(&self) -> &Self::Layout;
+
+        fn ranges(&self) -> impl Iterator<Item = Range<usize>>;
+    }
+
+    pub trait Loadable {
+        fn load_from_buf(&mut self, buffer: &buf, what: Range<usize>, into: usize);
+        fn load_from_cell(&mut self, buffer: &cell_buf, what: Range<usize>, into: usize);
+        fn load_from_atomic(&mut self, buffer: &atomic_buf, what: Range<usize>, into: usize);
+    }
+
+    pub trait Storable {
+        fn store_to_buf(&self, buffer: &mut buf, what: Range<usize>, into: usize);
+        fn store_to_cell(&self, buffer: &cell_buf, what: Range<usize>, into: usize);
+        fn store_to_atomic(&self, buffer: &atomic_buf, what: Range<usize>, into: usize);
+    }
+}
+
+use core::{cell::Cell, ops::Range};
+use sealed::{LayoutEngineCore, Loadable, Storable};
+
+use crate::buf::{atomic_buf, buf, cell_buf};
 use crate::image::{
     AtomicImage, AtomicImageRef, CellImage, CellImageRef, Image, ImageMut, ImageRef,
 };
 use crate::layout::{Bytes, Layout};
+use crate::texels;
 
 pub struct DataRef<'lt, Layout = Bytes> {
     data: &'lt [u8],
     layout: Layout,
+    offset: usize,
 }
 
 pub struct DataMut<'lt, Layout = Bytes> {
     data: &'lt mut [u8],
     layout: Layout,
+    offset: usize,
 }
 
 pub struct DataCells<'lt, Layout = Bytes> {
     data: &'lt [Cell<u8>],
     layout: Layout,
+    offset: usize,
 }
 
-macro_rules! transfer_methods {
-    (
-        derive {
-            $(write_to_buf: $write_to_buf:path,)?
-            $(read_from_buf: $read_from_buf:path,)?
+/// Borrows from a data source to read from it data into images.
+///
+/// The type parameter is the layout engine which defines the byte spans of data to be copied and
+/// in doing so controls the overhead of the operation. Note that the type must implement a sealed
+/// trait for all the main algorithms. The respective constructors on [`DataRef`], [`DataMut`],
+/// [`DataCells`]  choose this parameter.
+pub struct AsCopySource<'lt, E> {
+    inner: &'lt dyn Storable,
+    engine: E,
+}
+
+/// Borrows from a mutable data source to fill it with data from mages.
+///
+/// The type parameter is the layout engine which defines the byte spans of data to be copied and
+/// in doing so controls the overhead of the operation. Note that the type must implement a sealed
+/// trait for all the main algorithms. The respective constructors on [`DataRef`], [`DataMut`],
+/// [`DataCells`]  choose this parameter.
+pub struct AsCopyTarget<'lt, E> {
+    inner: &'lt mut dyn Loadable,
+    engine: E,
+}
+
+/// Documents the different layout engines.
+///
+/// This trait requires a sealed trait, it exists for documentation.
+pub trait LayoutEngine: sealed::LayoutEngineCore {}
+
+/// Copies all bytes within the bounds of this layout.
+pub struct WholeLayout<'lt, L> {
+    inner: &'lt L,
+    offset: usize,
+}
+
+impl<L: Layout> LayoutEngine for WholeLayout<'_, L> {}
+
+impl<L: Layout> sealed::LayoutEngineCore for WholeLayout<'_, L> {
+    type Layout = L;
+
+    fn layout(&self) -> &L {
+        self.inner
+    }
+
+    fn ranges(&self) -> impl Iterator<Item = Range<usize>> {
+        let bytes = self.inner.byte_len();
+        [self.offset..self.offset + bytes].into_iter()
+    }
+}
+
+impl<'lt> DataRef<'lt, Bytes> {
+    /// Treat a whole input buffer as image bytes.
+    pub fn new(data: &'lt [u8]) -> Self {
+        DataRef {
+            data,
+            layout: Bytes(core::mem::size_of_val(data)),
+            offset: 0,
         }
-    ) => {
-        $(
-            /// Write to an image, changing the layout in the process.
-            ///
-            /// See [`Self::write_to_image`] but works on a borrowed buffer, only when it has the same
-            /// layout type. Clones the layout to the image buffer.
-            ///
-            /// Reallocates the image buffer when necessary to ensure that the allocated buffer fits the
-            /// new data's layout.
-            ///
-            /// Consider [`Self::write_to_buf`] with the [`Image::as_capacity_buf_mut`] when you want to
-            /// ignore the layout value of the target buffer.
-            pub fn write_to(&self, buffer: &mut Image<L>)
-            where
-                L: Clone + Layout,
-            {
-                buffer.layout_mut_unguarded().clone_from(&self.layout);
-                buffer.ensure_layout();
-                $write_to_buf(self, buffer.as_capacity_buf_mut());
-            }
-
-            /// Write to an image, changing the layout in the process.
-            ///
-            /// Reallocates the image buffer when necessary to ensure that the allocated buffer fits the
-            /// new data's layout.
-            pub fn write_to_image(&self, buffer: Image<impl Layout>) -> Image<L>
-            where
-                L: Clone + Layout,
-            {
-                let mut buffer = buffer.with_layout(self.layout.clone());
-                $write_to_buf(self, buffer.as_capacity_buf_mut());
-                buffer
-            }
-
-            /// Write to a mutable borrowed buffer with layout.
-            ///
-            /// First verifies that the data will fit into the target. Then returns `Some` with a new
-            /// reference to the target buffer that is using the data's layout. Otherwise, returns `None`.
-            pub fn write_to_mut<'data>(
-                &self,
-                buffer: ImageMut<'data, impl Layout>,
-            ) -> Option<ImageMut<'data, L>>
-            where
-                L: Clone + Layout,
-            {
-                let mut buffer = buffer.with_layout(self.layout.clone())?;
-                $write_to_buf(self, buffer.as_mut_buf());
-                Some(buffer)
-            }
-        )* /*write_to_buf */
     }
 }
 
@@ -90,13 +121,23 @@ impl<'lt, L> DataRef<'lt, L> {
     /// Verifies the data against the layout before construction.
     ///
     /// Note that the type has no hard invariants.
-    pub fn checked_new(data: &'lt [u8], layout: L) -> Option<Self>
+    pub fn with_layout(data: &'lt [u8], layout: L, at: usize) -> Option<Self>
     where
         L: Layout,
     {
         Some(data)
-            .filter(|data| <dyn Layout>::fits_data(&layout, data))
-            .map(|data| DataRef { data, layout })
+            .filter(|data| {
+                if let Some(partial) = data.get(at..) {
+                    <dyn Layout>::fits_data(&layout, partial)
+                } else {
+                    false
+                }
+            })
+            .map(|data| DataRef {
+                data,
+                layout,
+                offset: Default::default(),
+            })
     }
 
     /// Copy the data bytes of the layout to the byte buffer.
@@ -104,11 +145,29 @@ impl<'lt, L> DataRef<'lt, L> {
         let len = buffer.len().min(core::mem::size_of_val(self.data));
         buffer[..len].copy_from_slice(self.data);
     }
+}
 
-    transfer_methods! {
-        derive {
-            write_to_buf: Self::write_to_buf,
-        }
+impl Storable for &'_ [u8] {
+    #[track_caller]
+    fn store_to_buf(&self, buffer: &mut buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let target = &mut buffer.as_bytes_mut()[into..][..len];
+        let source = &self[what.start..what.end];
+        target.copy_from_slice(source);
+    }
+
+    fn store_to_cell(&self, buffer: &cell_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = &buffer.as_texels(texels::U8).as_slice_of_cells()[into..][..len];
+        let target = &self[what.start..what.end];
+        texels::U8.store_cell_slice(source, target);
+    }
+
+    fn store_to_atomic(&self, buffer: &atomic_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let target = buffer.index(texels::U8.to_range(into..into + len).unwrap());
+        let source = &self[what.start..what.end];
+        texels::U8.store_atomic_slice(target, source);
     }
 }
 
@@ -116,13 +175,17 @@ impl<'lt, L> DataMut<'lt, L> {
     /// Verifies the data against the layout before construction.
     ///
     /// Note that the type has no hard invariants.
-    pub fn checked_new(data: &'lt mut [u8], layout: L) -> Option<Self>
+    pub fn new(data: &'lt mut [u8], layout: L) -> Option<Self>
     where
         L: Layout,
     {
         Some(data)
             .filter(|data| <dyn Layout>::fits_data(&layout, data))
-            .map(|data| DataMut { data, layout })
+            .map(|data| DataMut {
+                data,
+                layout,
+                offset: Default::default(),
+            })
     }
 
     /// Copy the data bytes of the layout to the byte buffer.
@@ -136,11 +199,322 @@ impl<'lt, L> DataMut<'lt, L> {
         let len = buffer.len().min(core::mem::size_of_val(self.data));
         self.data[..len].copy_from_slice(buffer);
     }
+}
 
-    transfer_methods! {
-        derive {
-            write_to_buf: Self::write_to_buf,
-            read_from_buf: Self::read_from_buf,
+impl Storable for &'_ mut [u8] {
+    #[track_caller]
+    fn store_to_buf(&self, buffer: &mut buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let target = &mut buffer.as_bytes_mut()[into..][..len];
+        let source = &self[what.start..what.end];
+        target.copy_from_slice(source);
+    }
+
+    fn store_to_cell(&self, buffer: &cell_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = &buffer.as_texels(texels::U8).as_slice_of_cells()[into..][..len];
+        let target = &self[what.start..what.end];
+        texels::U8.store_cell_slice(source, target);
+    }
+
+    fn store_to_atomic(&self, buffer: &atomic_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let target = buffer.index(texels::U8.to_range(into..into + len).unwrap());
+        let source = &self[what.start..what.end];
+        texels::U8.store_atomic_slice(target, source);
+    }
+}
+
+impl Loadable for &'_ mut [u8] {
+    #[track_caller]
+    fn load_from_buf(&mut self, buffer: &buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = &buffer.as_bytes()[into..][..len];
+        let target = &mut self[what.start..what.end];
+        target.copy_from_slice(source);
+    }
+
+    fn load_from_cell(&mut self, buffer: &cell_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = &buffer.as_texels(texels::U8).as_slice_of_cells()[into..][..len];
+        let target = &mut self[what.start..what.end];
+        texels::U8.load_cell_slice(source, target);
+    }
+
+    fn load_from_atomic(&mut self, buffer: &atomic_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = buffer.index(texels::U8.to_range(into..into + len).unwrap());
+        let target = &mut self[what.start..what.end];
+        texels::U8.load_atomic_slice(source, target);
+    }
+}
+
+impl<'lt, L> DataCells<'lt, L> {
+    /// Verifies the data against the layout before construction.
+    ///
+    /// Note that the type has no hard invariants.
+    pub fn new(data: &'lt [Cell<u8>], layout: L) -> Option<Self>
+    where
+        L: Layout,
+    {
+        Some(data)
+            .filter(|data| <dyn Layout>::fits_data(&layout, data))
+            .map(|data| DataCells {
+                data,
+                layout,
+                offset: Default::default(),
+            })
+    }
+
+    /// Copy the data bytes of the layout to the byte buffer.
+    #[track_caller]
+    pub fn write_to_buf(&self, buffer: &mut buf) {
+        let len = core::mem::size_of_val(self.data);
+        self.data.store_to_buf(buffer, 0..len, 0);
+    }
+
+    /// Copy the data bytes of the layout to the byte buffer.
+    pub fn read_from_buf(&mut self, buffer: &buf) {
+        let len = core::mem::size_of_val(self.data);
+        self.data.load_from_buf(buffer, 0..len, 0);
+    }
+
+    /// Copy all bytes contained in this layout.
+    pub fn as_source(&self) -> AsCopySource<'_, WholeLayout<'_, L>>
+    where
+        L: Layout,
+    {
+        AsCopySource {
+            inner: &self.data,
+            engine: WholeLayout {
+                inner: &self.layout,
+                offset: self.offset,
+            },
         }
+    }
+
+    /// Copy all bytes contained in this layout.
+    pub fn as_target(&mut self) -> AsCopyTarget<'_, WholeLayout<'_, L>>
+    where
+        L: Layout,
+    {
+        AsCopyTarget {
+            inner: &mut self.data,
+            engine: WholeLayout {
+                inner: &self.layout,
+                offset: self.offset,
+            },
+        }
+    }
+}
+
+impl Storable for &'_ [Cell<u8>] {
+    #[track_caller]
+    fn store_to_buf(&self, buffer: &mut buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let target = &mut buffer.as_bytes_mut()[into..][..len];
+        let source = &self[what.start..what.end];
+        crate::texels::U8.load_cell_slice(source, target);
+    }
+
+    #[track_caller]
+    fn store_to_cell(&self, buffer: &cell_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = &buffer.as_texels(texels::U8).as_slice_of_cells()[into..][..len];
+        let target = &self[what.start..what.end];
+        texels::U8.cell_memory_copy(source, target);
+    }
+
+    #[track_caller]
+    fn store_to_atomic(&self, buffer: &atomic_buf, what: Range<usize>, into: usize) {
+        todo!()
+    }
+}
+
+impl Loadable for &'_ [Cell<u8>] {
+    #[track_caller]
+    fn load_from_buf(&mut self, buffer: &buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = &buffer.as_bytes()[into..][..len];
+        let target = &self[what.start..what.end];
+        texels::U8.store_cell_slice(target, source);
+    }
+
+    fn load_from_cell(&mut self, buffer: &cell_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = &buffer.as_texels(texels::U8).as_slice_of_cells()[into..][..len];
+        let target = &self[what.start..what.end];
+        texels::U8.cell_memory_copy(source, target);
+    }
+
+    fn load_from_atomic(&mut self, buffer: &atomic_buf, what: Range<usize>, into: usize) {
+        let len = what.len();
+        let source = buffer.index(texels::U8.to_range(into..into + len).unwrap());
+        todo!()
+    }
+}
+
+impl<E: LayoutEngine> AsCopySource<'_, E> {
+    fn engine_to_buf_at(&self, buffer: &mut buf, offset: usize) {
+        // Make sure we compile this once per iterator type. Then for instance there is only one
+        // such instance for all LayoutEngine types instead of one per different layout
+        #[inline(never)]
+        fn ranges_to_buf_at(
+            ranges: impl Iterator<Item = Range<usize>>,
+            store: &dyn Storable,
+            buffer: &mut buf,
+            offset: usize,
+        ) {
+            for range in ranges {
+                store.store_to_buf(buffer, range, offset)
+            }
+        }
+
+        ranges_to_buf_at(self.engine.ranges(), self.inner, buffer, offset);
+    }
+
+    fn engine_to_cell_buf_at(&self, buffer: &cell_buf, offset: usize) {
+        // Make sure we compile this once per iterator type. Then for instance there is only one
+        // such instance for all LayoutEngine types instead of one per different layout
+        #[inline(never)]
+        fn ranges_to_buf_at(
+            ranges: impl Iterator<Item = Range<usize>>,
+            store: &dyn Storable,
+            buffer: &cell_buf,
+            offset: usize,
+        ) {
+            for range in ranges {
+                store.store_to_cell(buffer, range, offset)
+            }
+        }
+
+        ranges_to_buf_at(self.engine.ranges(), self.inner, buffer, offset);
+    }
+
+    fn engine_to_atomic_buf_at(&self, buffer: &atomic_buf, offset: usize) {
+        // Make sure we compile this once per iterator type. Then for instance there is only one
+        // such instance for all LayoutEngine types instead of one per different layout
+        #[inline(never)]
+        fn ranges_to_buf_at(
+            ranges: impl Iterator<Item = Range<usize>>,
+            store: &dyn Storable,
+            buffer: &atomic_buf,
+            offset: usize,
+        ) {
+            for range in ranges {
+                store.store_to_atomic(buffer, range, offset)
+            }
+        }
+
+        ranges_to_buf_at(self.engine.ranges(), self.inner, buffer, offset);
+    }
+
+    /// Write to an image, changing the layout in the process.
+    ///
+    /// See [`Self::write_to_image`] but works on a borrowed buffer, only when it has the same
+    /// layout type. Clones the layout to the image buffer.
+    ///
+    /// Reallocates the image buffer when necessary to ensure that the allocated buffer fits the
+    /// new data's layout.
+    ///
+    /// Consider [`Self::write_to_buf`] with the [`Image::as_capacity_buf_mut`] when you want to
+    /// ignore the layout value of the target buffer.
+    pub fn write_to<L>(&self, buffer: &mut Image<E::Layout>)
+    where
+        E::Layout: Clone + Layout,
+    {
+        let layout = self.engine.layout();
+        buffer.layout_mut_unguarded().clone_from(layout);
+        buffer.ensure_layout();
+        self.engine_to_buf_at(buffer.as_capacity_buf_mut(), 0);
+    }
+
+    /// Write to an image, changing the layout in the process.
+    ///
+    /// Reallocates the image buffer when necessary to ensure that the allocated buffer fits the
+    /// new data's layout.
+    pub fn write_to_image(&self, buffer: Image<impl Layout>) -> Image<E::Layout>
+    where
+        E::Layout: Clone + Layout,
+    {
+        let mut buffer = buffer.with_layout(self.engine.layout().clone());
+        self.engine_to_buf_at(buffer.as_capacity_buf_mut(), 0);
+        buffer
+    }
+
+    /// Write to a mutable borrowed buffer with layout.
+    ///
+    /// First verifies that the data will fit into the target. Then returns `Some` with a new
+    /// reference to the target buffer that is using the data's layout. Otherwise, returns `None`.
+    pub fn write_to_mut<'data>(
+        &self,
+        buffer: ImageMut<'data, impl Layout>,
+    ) -> Option<ImageMut<'data, E::Layout>>
+    where
+        E::Layout: Clone + Layout,
+    {
+        let mut buffer = buffer.with_layout(self.engine.layout().clone())?;
+        self.engine_to_buf_at(buffer.as_mut_buf(), 0);
+        Some(buffer)
+    }
+
+    /// Write to a locally shared buffer with layout.
+    ///
+    /// First verifies that the data will fit into the target. Then returns `Some` with a new
+    /// reference to the target buffer that is using the data's layout. Otherwise, returns `None`.
+    pub fn write_to_cell_ref<'data>(
+        &self,
+        buffer: CellImageRef<'data, impl Layout>,
+    ) -> Option<CellImageRef<'data, E::Layout>>
+    where
+        E::Layout: Clone + Layout,
+    {
+        let buffer = buffer.checked_with_layout(self.engine.layout().clone())?;
+        self.engine_to_cell_buf_at(buffer.as_cell_buf(), 0);
+        Some(buffer)
+    }
+
+    /// Write to a mutable borrowed buffer with layout.
+    ///
+    /// First verifies that the data will fit into the target. Then returns `Some` with a new
+    /// reference to the target buffer that is using the data's layout. Otherwise, returns `None`.
+    pub fn write_to_atomic_ref<'data>(
+        &self,
+        buffer: AtomicImageRef<'data, impl Layout>,
+    ) -> Option<AtomicImageRef<'data, E::Layout>>
+    where
+        E::Layout: Clone + Layout,
+    {
+        let buffer = buffer.checked_with_layout(self.engine.layout().clone())?;
+        self.engine_to_atomic_buf_at(buffer.as_capacity_atomic_buf(), 0);
+        Some(buffer)
+    }
+}
+
+impl<E: LayoutEngine> AsCopyTarget<'_, E> {
+    fn engine_from_buf_at(&mut self, buffer: &buf, offset: usize) {
+        // Make sure we compile this once per iterator type. Then for instance there is only one
+        // such instance for all LayoutEngine types instead of one per different layout
+        #[inline(never)]
+        fn ranges_from_buf_at(
+            ranges: impl Iterator<Item = Range<usize>>,
+            store: &mut dyn Loadable,
+            buffer: &buf,
+            offset: usize,
+        ) {
+            for range in ranges {
+                store.load_from_buf(buffer, range, offset)
+            }
+        }
+
+        ranges_from_buf_at(self.engine.ranges(), self.inner, buffer, offset);
+    }
+
+    /// Read out data from a borrowed buffer.
+    ///
+    /// This reads data up to our layout. It does not interpret the data with the layout of
+    /// the argument buffer.
+    pub fn read_from_ref(&mut self, buffer: ImageRef<'_, impl Layout>) {
+        self.engine_from_buf_at(buffer.as_buf(), 0);
     }
 }

--- a/texel/src/layout.rs
+++ b/texel/src/layout.rs
@@ -75,6 +75,11 @@ impl dyn Layout + '_ {
     pub fn fits_cell_buf(&self, bytes: &crate::buf::cell_buf) -> bool {
         self.byte_len() <= bytes.len()
     }
+
+    #[inline]
+    pub fn fits_data(&self, len: &impl ?Sized) -> bool {
+        self.byte_len() <= core::mem::size_of_val(len)
+    }
 }
 
 /// Convert one layout to a less strict one.

--- a/texel/src/layout.rs
+++ b/texel/src/layout.rs
@@ -16,6 +16,7 @@ use crate::image::{Coord, ImageMut, ImageRef};
 pub use crate::stride::{BadStrideError, StrideSpec, StridedBytes, StridedLayout, Strides};
 pub use matrix::{Matrix, MatrixBytes, MatrixLayout};
 pub use planar::{PlaneBytes, PlaneMatrices, Planes};
+pub use relocated::Relocated;
 pub(crate) use upsampling::Yuv420p;
 
 /// A byte layout that only describes the user bytes.

--- a/texel/src/layout.rs
+++ b/texel/src/layout.rs
@@ -92,7 +92,9 @@ impl dyn Layout + '_ {
 ///
 /// In general, a layout `L` should implement `Decay<T>` if any image with layouts of type `T` is
 /// also valid for some layout of type `L`. A common example would be if a crate strictly adds more
-/// information to a predefined layout, then it should also decay to that layout.
+/// information to a predefined layout, then it should also decay to that layout. It is invalid to
+/// decay to a layout that somehow expands outside the initial layout, you must weaken the buffer
+/// required.
 ///
 /// Also note that this trait is not reflexive, in contrast to `From` and `Into` which are. This
 /// avoids collisions in impls. In particular, it allows adding blanket impls of the form

--- a/texel/src/layout/planar.rs
+++ b/texel/src/layout/planar.rs
@@ -130,6 +130,10 @@ impl<const N: usize> PlaneBytes<N> {
         }
     }
 
+    pub fn from_repeated(matrix: MatrixBytes) -> Self {
+        Self::new([matrix; N])
+    }
+
     /// Return a reference to one relocated matrix layout.
     pub fn plane_ref(&self, idx: usize) -> Option<&Relocated<MatrixBytes>> {
         self.planes.inner.get(idx)

--- a/texel/src/layout/relocated.rs
+++ b/texel/src/layout/relocated.rs
@@ -1,6 +1,9 @@
 use crate::layout::{AlignedOffset, Decay, Layout, PlaneOf, Relocate, SliceLayout};
 use crate::texels::TexelRange;
 
+/// Moves a base layout to an aligned offset location.
+///
+/// This effectively allows turning one layout into a plane of another.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Relocated<T> {
     pub offset: AlignedOffset,
@@ -49,6 +52,15 @@ impl<T: Layout> Relocate for Relocated<T> {
 impl<T: Layout> Decay<T> for Relocated<T> {
     fn decay(inner: T) -> Relocated<T> {
         Relocated::new(inner)
+    }
+}
+
+impl<T: Layout> Decay<Relocated<Relocated<T>>> for Relocated<T> {
+    fn decay(inner: Relocated<Relocated<T>>) -> Relocated<T> {
+        Relocated {
+            offset: AlignedOffset::new(inner.offset.get() + inner.inner.offset.get()).unwrap(),
+            inner: inner.inner.inner,
+        }
     }
 }
 

--- a/texel/src/texel.rs
+++ b/texel/src/texel.rs
@@ -970,7 +970,7 @@ impl<P> Texel<P> {
     #[track_caller]
     pub(crate) fn cell_memory_copy(self, a: &[Cell<P>], b: &[Cell<P>]) {
         assert_eq!(a.len(), b.len());
-        // SAFETY:
+        // Safety:
         // - the source is readable for `len` units
         // - the target is writable for `len` items
         // - the Texel certifies that this copy creates valid values
@@ -990,7 +990,7 @@ impl<P> Texel<P> {
             return false;
         }
 
-        // SAFETY: the same reasoning applies for both.
+        // Safety: the same reasoning applies for both.
         // - this covers the exact memory range as the underlying slice of cells.
         // - the Texel certifies it is initialized memory.
         // - the lifetime is the same.
@@ -1016,7 +1016,7 @@ impl<P> Texel<P> {
             return false;
         }
 
-        // SAFETY: see `cell_memory_eq`.
+        // Safety: see `cell_memory_eq`.
         let lhs: &'a [u8] = unsafe { slice::from_raw_parts(a.as_ptr() as *const u8, len) };
 
         // Really these two should not be overlapping! If the compiler knew, maybe a better memory

--- a/texel/tests/atomic.rs
+++ b/texel/tests/atomic.rs
@@ -2,6 +2,7 @@ use image_texel::texels::{AtomicBuffer, U32};
 use std::{mem, thread};
 
 #[test]
+#[cfg(not(miri))]
 fn mapping_atomics_parallel() {
     const LEN: usize = 128;
     let buffer = AtomicBuffer::new(LEN * mem::size_of::<u32>());

--- a/texel/tests/data_transfer.rs
+++ b/texel/tests/data_transfer.rs
@@ -30,7 +30,7 @@ fn planar_io() {
     let target = Image::new(layout.clone());
 
     let data = DataRef::with_layout_at(input.data, input.layout, 0).unwrap();
-    let reinterpreted = data.as_source().write_to_image(target);
+    let reinterpreted = data.as_source().write_to_image(target.decay());
 
     // Layout must match, as must the bytes within the layout.
     assert_eq!(*reinterpreted.layout(), input.layout);
@@ -45,11 +45,11 @@ fn planar_io() {
     assert_ne!(small.as_buf().as_bytes(), input.data);
     assert_ne!(post.as_buf().as_bytes(), input.data);
 
-    assert!(data.as_source().write_to_mut(small).is_none());
+    assert!(data.as_source().write_to_mut(small.decay()).is_none());
 
     let post = data
         .as_source()
-        .write_to_mut(post)
+        .write_to_mut(post.decay())
         .expect("that plane was large enough");
     // Modify that other independent plane for good measure.
     pre.as_mut_buf().fill(0);

--- a/texel/tests/data_transfer.rs
+++ b/texel/tests/data_transfer.rs
@@ -11,7 +11,7 @@ fn same_layout_io() {
     let mut target = Image::new(initially_empty);
 
     let data = DataRef::with_layout_at(input.data, input.layout, 0).unwrap();
-    data.as_source().write_to(&mut target);
+    target.assign(data.as_source());
 
     // Layout must match, as must the bytes within the layout.
     assert_eq!(*target.layout(), input.layout);

--- a/texel/tests/data_transfer.rs
+++ b/texel/tests/data_transfer.rs
@@ -1,0 +1,84 @@
+use std::sync::OnceLock;
+
+use image_texel::image::{DataRef, Image};
+use image_texel::layout::{MatrixBytes, PlaneBytes};
+
+#[test]
+fn same_layout_io() {
+    let input = TestData::hello_img();
+
+    let initially_empty = MatrixBytes::empty(input.layout.element());
+    let mut target = Image::new(initially_empty);
+
+    let data = DataRef::with_layout_at(input.data, input.layout, 0).unwrap();
+    data.as_source().write_to(&mut target);
+
+    // Layout must match, as must the bytes within the layout.
+    assert_eq!(*target.layout(), input.layout);
+    assert_eq!(target.as_buf().as_bytes(), input.data);
+}
+
+#[test]
+fn planar_io() {
+    let input = TestData::hello_img();
+
+    let layout: PlaneBytes<3> = PlaneBytes::new({
+        let smaller = MatrixBytes::from_width_height(input.layout.element(), 1, 1).unwrap();
+        [input.layout, smaller, input.layout]
+    });
+
+    let target = Image::new(layout.clone());
+
+    let data = DataRef::with_layout_at(input.data, input.layout, 0).unwrap();
+    let reinterpreted = data.as_source().write_to_image(target);
+
+    // Layout must match, as must the bytes within the layout.
+    assert_eq!(*reinterpreted.layout(), input.layout);
+    assert_eq!(reinterpreted.as_buf().as_bytes(), input.data);
+
+    let mut target = reinterpreted.with_layout(layout);
+    // FIXME: see Design Issues in `unaligned`. This is not intuitive.
+    let [mut pre, small, post] = target.as_mut().into_planes([0, 1, 2]).unwrap();
+
+    // We've just written that plane.
+    assert_eq!(pre.as_buf().as_bytes(), input.data);
+    assert_ne!(small.as_buf().as_bytes(), input.data);
+    assert_ne!(post.as_buf().as_bytes(), input.data);
+
+    assert!(data.as_source().write_to_mut(small).is_none());
+
+    let post = data
+        .as_source()
+        .write_to_mut(post)
+        .expect("that plane was large enough");
+    // Modify that other independent plane for good measure.
+    pre.as_mut_buf().fill(0);
+
+    assert_eq!(*post.layout(), input.layout);
+    assert_eq!(post.as_buf().as_bytes(), input.data);
+}
+
+struct TestData {
+    layout: MatrixBytes,
+    data: &'static [u8],
+}
+
+impl TestData {
+    fn hello_img() -> Self {
+        static OFFSET_DATA: OnceLock<Box<[u8]>> = OnceLock::new();
+        type Component = u32;
+
+        let texel = <Component as image_texel::AsTexel>::texel();
+        let layout = MatrixBytes::from_width_height(texel.into(), 16, 16).expect("Valid, actually");
+
+        let raw_data = OFFSET_DATA.get_or_init(|| {
+            let aligned: Vec<_> = (0u32..16 * 16).collect();
+            let mut unalign = vec![0x42u8];
+            unalign.extend_from_slice(bytemuck::cast_slice(&aligned));
+            unalign.into()
+        });
+
+        let data = &raw_data[1..];
+        TestData { layout, data }
+    }
+}


### PR DESCRIPTION
Mainly introduces `AsCopySource` and `AsCopyTarget` which borrow some potentially _unaligned_ buffer. They then generate byte spans to be transferred between this and any of `{,Cell,Atomic}Image{_Ref,Mut}` under an arbitrary layout interpretation of the copy buffer, *not* the target. That is we can copy a byte matrix into a `Matrix<T>` and it is up to the user to match the layout of the two.

Conversely, Images can be assigned from a data source in which case they will also changed to the source's layout.

It's not perfectly ergonomic as documented in `src/image/data.rs`. The biggest pain point may be assigning into and copying from a planar portion of an image. Here, one has to manually do index juggling and bookkeeping to get all the layouts and offsets to match, which is properly annoying.

Also, the only copy strategy implemented currently is copying the *full* layout and copying a relocated layout (those correspond to copying the bytes `..len` and `start..len` respectively). In planar cases this will read and touch many bytes unnecessarily. Also a common case specifically for matrix data is a difference between the row layout of the source and target of copying (as captured by [`wgpu::TexelCopyBufferLayout`](https://docs.rs/wgpu/latest/wgpu/struct.TexelCopyBufferLayout.html)). This could be easily done on the fly if we're copying each row as a separate range but is not yet implemented.