### PR TITLE
Polish byte buffer wrappers for release

### DIFF
--- a/canvas/Cargo.toml
+++ b/canvas/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/image-rs/canvas"
 categories = ["multimedia::images"]
 
 [dependencies]
-image-texel = { path = "../texel", version = "0.4.0" }
+image-texel = { path = "../texel", version = "0.5.0" }
 bytemuck = "1.1"
 
 [dev-dependencies]

--- a/texel/Cargo.toml
+++ b/texel/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "image-texel"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.77"
 
 description = "A texel type and allocated buffers suitable for image data."
-authors = ["Aurelia Molzer <andreas.molzer@gmx.de>"]
+authors = ["Aurelia Molzer <5550310+HeroicKatora@users.noreply.github.com>"]
 license = "MIT"
 readme = "Readme.md"
 documentation = "https://docs.rs/image-texel"

--- a/texel/src/buf.rs
+++ b/texel/src/buf.rs
@@ -1443,6 +1443,34 @@ impl<P> Clone for AtomicSliceRef<'_, P> {
 
 impl<P> Copy for AtomicSliceRef<'_, P> {}
 
+impl<P> AtomicRef<'_, P> {
+    /// Modify the value stored in the reference.
+    ///
+    /// Note that this does *not* promise to be atomic in the whole value, just that it atomically
+    /// modifies the underlying buffer elements. The bytes of the value may be torn if another
+    /// write happens concurrently to the same element.
+    ///
+    /// However, it is guaranteed that the contents of any other non-aliased value in the buffer is
+    /// not modified even if they share the same atomic unit.
+    pub fn store(self, value: P) {
+        self.texel.store_atomic(self, value);
+    }
+
+    /// Retrieve a value stored in the reference.
+    ///
+    /// Note that this does *not* promise to be atomic in the whole value, just that it atomically
+    /// reads from the underlying buffer. The bytes of the value may be torn if another write
+    /// happens concurrently to the same element.
+    ///
+    /// If no such write occurs concurrently, when all writes are ordered-before or ordered-after
+    /// this load then the value is correct. This needs only hold to writes accessing the bytes
+    /// making up _this value_. Even if another values shares atomic units with this value their
+    /// writes are guaranteed to never modify the bits of this value.
+    pub fn load(self) -> P {
+        self.texel.load_atomic(self)
+    }
+}
+
 impl<P> Clone for AtomicRef<'_, P> {
     fn clone(&self) -> Self {
         AtomicRef { ..*self }

--- a/texel/src/image.rs
+++ b/texel/src/image.rs
@@ -10,8 +10,9 @@
 //! advised, probably very common, and the only 'supported' use-case).
 mod atomic;
 mod cell;
-mod data;
 mod raw;
+
+pub mod data;
 
 use core::{fmt, ops};
 
@@ -26,7 +27,7 @@ use crate::{BufferReuseError, Texel, TexelBuffer};
 pub use crate::stride::{StridedBufferMut, StridedBufferRef};
 pub use atomic::{AtomicImage, AtomicImageRef};
 pub use cell::{CellImage, CellImageRef};
-pub use data::{DataCells, DataMut, DataRef};
+pub use data::{AsCopySource, AsCopyTarget, DataCells, DataMut, DataRef};
 
 /// A container of allocated bytes, parameterized over the layout.
 ///

--- a/texel/src/image.rs
+++ b/texel/src/image.rs
@@ -582,11 +582,37 @@ impl<'data, L> ImageRef<'data, L> {
     }
 
     /// Copy all bytes to a newly allocated image.
-    pub fn to_owned(&self) -> Image<L>
-    where
-        L: Layout + Clone,
-    {
-        Image::with_bytes(self.inner.layout().clone(), self.inner.as_bytes())
+    ///
+    /// Note this will allocate a buffer according to the capacity length of this reference, not
+    /// merely the layout. When this is not the intention, consider calling [`Self::split_layout`]
+    /// or [`Self::truncate_layout`] respectively.
+    ///
+    /// # Examples
+    ///
+    /// Here we make an independent copy of the second plane of a composite image.
+    ///
+    /// ```
+    /// use image_texel::image::{Image, ImageRef};
+    /// use image_texel::layout::{PlaneMatrices, Matrix};
+    /// use image_texel::texels::U8;
+    ///
+    /// let mat = Matrix::from_width_height(U8, 8, 8).unwrap();
+    /// let buffer = Image::new(PlaneMatrices::<_, 2>::from_repeated(mat));
+    ///
+    /// // … some code to initialize those planes.
+    /// # let mut buffer = buffer;
+    /// # buffer.as_mut().into_planes([1]).unwrap()[0]
+    /// #     .as_capacity_buf_mut()[..8].copy_from_slice(b"not zero");
+    /// # let buffer = buffer;
+    ///
+    /// let [p1] = buffer.as_ref().into_planes([1]).unwrap();
+    /// let clone_of: Image<_> = p1.into_owned();
+    ///
+    /// let [p1] = buffer.as_ref().into_planes([1]).unwrap();
+    /// assert_eq!(clone_of.as_bytes(), p1.as_bytes());
+    /// ```
+    pub fn into_owned(self) -> Image<L> {
+        self.inner.into_owned().into()
     }
 
     /// Get a slice of the individual samples in the layout.
@@ -661,6 +687,18 @@ impl<'data, L> ImageRef<'data, L> {
         *buffer = initial;
 
         RawImage::from_buffer(Bytes(next.len()), next).into()
+    }
+
+    /// Remove all past-the-layout bytes.
+    ///
+    /// This is a utility to combine with pipelining. It is equivalent to calling
+    /// [`Self::split_layout`] and discarding that result.
+    pub fn truncate_layout(mut self) -> Self
+    where
+        L: Layout,
+    {
+        let _ = self.split_layout();
+        self
     }
 
     /// Split this reference into independent planes.
@@ -885,14 +923,6 @@ impl<'data, L> ImageMut<'data, L> {
         Some(self.inner.checked_decay()?.into())
     }
 
-    /// Copy the bytes and layout to an owned container.
-    pub fn to_owned(&self) -> Image<L>
-    where
-        L: Layout + Clone,
-    {
-        Image::with_bytes(self.inner.layout().clone(), self.inner.as_bytes())
-    }
-
     /// Get a slice of the individual samples in the layout.
     pub fn as_slice(&self) -> &[L::Sample]
     where
@@ -935,6 +965,38 @@ impl<'data, L> ImageMut<'data, L> {
         L: Layout,
     {
         pixel.cast_mut_buf(self.inner.as_mut_buf())
+    }
+
+    /// Copy all bytes to a newly allocated image.
+    ///
+    /// Note this will allocate a buffer according to the capacity length of this reference, not
+    /// merely the layout. When this is not the intention, consider calling [`Self::split_layout`]
+    /// or [`Self::truncate_layout`] respectively.
+    ///
+    /// # Examples
+    ///
+    /// Here we make an independent copy of the second plane of a composite image.
+    ///
+    /// ```
+    /// use image_texel::image::{Image, ImageRef};
+    /// use image_texel::layout::{PlaneMatrices, Matrix};
+    /// use image_texel::texels::U8;
+    ///
+    /// let mat = Matrix::from_width_height(U8, 8, 8).unwrap();
+    /// let mut buffer = Image::new(PlaneMatrices::<_, 2>::from_repeated(mat));
+    ///
+    /// // … some code to initialize those planes.
+    /// # buffer.as_mut().into_planes([1]).unwrap()[0]
+    /// #     .as_capacity_buf_mut()[..8].copy_from_slice(b"not zero");
+    ///
+    /// let [p1] = buffer.as_mut().into_planes([1]).unwrap();
+    /// let clone_of: Image<_> = p1.into_owned();
+    ///
+    /// let [p1] = buffer.as_ref().into_planes([1]).unwrap();
+    /// assert_eq!(clone_of.as_bytes(), p1.as_bytes());
+    /// ```
+    pub fn into_owned(self) -> Image<L> {
+        self.inner.into_owned().into()
     }
 
     /// Turn into a slice of the individual samples in the layout.
@@ -1010,6 +1072,18 @@ impl<'data, L> ImageMut<'data, L> {
         *buffer = initial;
 
         RawImage::from_buffer(Bytes(next.len()), next).into()
+    }
+
+    /// Remove all past-the-layout bytes.
+    ///
+    /// This is a utility to combine with pipelining. It is equivalent to calling
+    /// [`Self::split_layout`] and discarding that result.
+    pub fn truncate_layout(mut self) -> Self
+    where
+        L: Layout,
+    {
+        let _ = self.split_layout();
+        self
     }
 
     /// Split this mutable reference into independent planes.

--- a/texel/src/image/atomic.rs
+++ b/texel/src/image/atomic.rs
@@ -25,7 +25,7 @@ use crate::{BufferReuseError, Texel, TexelBuffer};
 /// manner.
 #[derive(Clone)]
 pub struct AtomicImage<Layout = Bytes> {
-    inner: RawImage<AtomicBuffer, Layout>,
+    pub(super) inner: RawImage<AtomicBuffer, Layout>,
 }
 
 /// A partial view of an atomic image.
@@ -35,7 +35,7 @@ pub struct AtomicImage<Layout = Bytes> {
 /// by calling [`AtomicImage::as_ref`] or [`AtomicImage::checked_to_ref`].
 #[derive(Clone, PartialEq, Eq)]
 pub struct AtomicImageRef<'buf, Layout = &'buf Bytes> {
-    inner: RawImage<&'buf atomic_buf, Layout>,
+    pub(super) inner: RawImage<&'buf atomic_buf, Layout>,
 }
 
 /// Image methods for all layouts.

--- a/texel/src/image/atomic.rs
+++ b/texel/src/image/atomic.rs
@@ -2,7 +2,7 @@
 //!
 //! Re-exported at its super `image` module.
 use crate::buf::{atomic_buf, AtomicBuffer, AtomicSliceRef};
-use crate::image::{raw::RawImage, IntoPlanesError};
+use crate::image::{raw::RawImage, Image, IntoPlanesError};
 use crate::layout::{Bytes, Decay, Layout, Mend, PlaneOf, Relocate, SliceLayout, Take, TryMend};
 use crate::texel::{constants::U8, MAX_ALIGN};
 use crate::{BufferReuseError, Texel, TexelBuffer};
@@ -144,6 +144,36 @@ impl<L: Layout> AtomicImage<L> {
         M: Layout,
     {
         Some(self.inner.checked_decay()?.into())
+    }
+
+    /// Copy all bytes to a newly allocated image.
+    ///
+    /// Note this will allocate a buffer according to the capacity length of this reference, not
+    /// merely the layout. When this is not the intention, consider calling [`Self::split_layout`]
+    /// or [`Self::truncate_layout`] respectively.
+    ///
+    /// # Examples
+    ///
+    /// Here we make an independent copy of a pixel matrix image.
+    ///
+    /// ```
+    /// use image_texel::image::{AtomicImage, Image};
+    /// use image_texel::layout::{PlaneMatrices, Matrix};
+    /// use image_texel::texels::U8;
+    ///
+    /// let matrix = Matrix::from_width_height(U8, 8, 8).unwrap();
+    /// let buffer = AtomicImage::new(matrix);
+    ///
+    /// // … some code to initialize those planes.
+    /// # let data = buffer.as_texels(U8).index(0..8);
+    /// # U8.store_atomic_slice(data, b"not zero");
+    ///
+    /// let clone_of: Image<_> = buffer.clone().into_owned();
+    ///
+    /// assert!(clone_of.as_bytes() == buffer.as_texels(U8).to_vec());
+    /// ```
+    pub fn into_owned(self) -> Image<L> {
+        self.inner.into_owned().into()
     }
 
     /// Move the bytes into a new image.
@@ -438,6 +468,38 @@ impl<'data, L> AtomicImageRef<'data, L> {
         Some(self.inner.checked_decay()?.into())
     }
 
+    /// Copy all bytes to a newly allocated image.
+    ///
+    /// Note this will allocate a buffer according to the capacity length of this reference, not
+    /// merely the layout. When this is not the intention, consider calling [`Self::split_layout`]
+    /// or [`Self::truncate_layout`] respectively.
+    ///
+    /// # Examples
+    ///
+    /// Here we make an independent copy of a pixel matrix image.
+    ///
+    /// ```
+    /// use image_texel::image::{AtomicImage, Image};
+    /// use image_texel::layout::{PlaneMatrices, Matrix};
+    /// use image_texel::texels::U8;
+    ///
+    /// let matrix = Matrix::from_width_height(U8, 8, 8).unwrap();
+    /// let buffer = AtomicImage::new(PlaneMatrices::<_, 2>::from_repeated(matrix));
+    ///
+    /// // … some code to initialize those planes.
+    /// # let [plane] = buffer.as_ref().into_planes([1]).unwrap();
+    /// # let data = buffer.as_texels(U8).index(0..8);
+    /// # U8.store_atomic_slice(data, b"not zero");
+    ///
+    /// let [plane1] = buffer.as_ref().into_planes([1]).unwrap();
+    /// let clone_of: Image<_> = plane1.clone().into_owned();
+    ///
+    /// assert!(clone_of.as_bytes() == plane1.as_texels(U8).to_vec());
+    /// ```
+    pub fn into_owned(self) -> Image<L> {
+        self.inner.into_owned().into()
+    }
+
     /// Get a slice of the individual samples in the layout.
     pub fn as_slice(&self) -> AtomicSliceRef<'_, L::Sample>
     where
@@ -473,11 +535,7 @@ impl<'data, L> AtomicImageRef<'data, L> {
         let (buffer, layout) = self.inner.into_parts();
         let len = layout.byte_len();
 
-        // FIXME: avoid zero-initializing. Might need a bit more unsafe code that extends a vector
-        // of Texel<P> from that atomic.
-        let mut target = alloc::vec![0; len];
-        U8.load_atomic_slice(buffer.as_texels(U8).truncate_bytes(len), &mut target);
-        target
+        buffer.as_texels(U8).truncate_bytes(len).to_vec()
     }
 
     /// Turn into a slice of the individual samples in the layout.
@@ -546,6 +604,18 @@ impl<'data, L> AtomicImageRef<'data, L> {
         *buffer = initial;
 
         RawImage::from_buffer(Bytes(next.len()), next).into()
+    }
+
+    /// Remove all past-the-layout bytes.
+    ///
+    /// This is a utility to combine with pipelining. It is equivalent to calling
+    /// [`Self::split_layout`] and discarding that result.
+    pub fn truncate_layout(mut self) -> Self
+    where
+        L: Layout,
+    {
+        let _ = self.split_layout();
+        self
     }
 
     /// Split this reference into independent planes.

--- a/texel/src/image/atomic.rs
+++ b/texel/src/image/atomic.rs
@@ -149,8 +149,8 @@ impl<L: Layout> AtomicImage<L> {
     /// Copy all bytes to a newly allocated image.
     ///
     /// Note this will allocate a buffer according to the capacity length of this reference, not
-    /// merely the layout. When this is not the intention, consider calling [`Self::split_layout`]
-    /// or [`Self::truncate_layout`] respectively.
+    /// merely the layout. When this is not the intention, consider first adjusting the buffer by
+    /// reference with [`Self::as_ref`].
     ///
     /// # Examples
     ///

--- a/texel/src/image/cell.rs
+++ b/texel/src/image/cell.rs
@@ -15,7 +15,7 @@ use core::cell::Cell;
 /// between threads. In particular the same buffer may be owned and viewed with different layouts.
 #[derive(Clone, PartialEq, Eq)]
 pub struct CellImage<Layout = Bytes> {
-    inner: RawImage<CellBuffer, Layout>,
+    pub(super) inner: RawImage<CellBuffer, Layout>,
 }
 
 /// A partial view of an atomic image.
@@ -25,7 +25,7 @@ pub struct CellImage<Layout = Bytes> {
 /// by calling [`CellImage::as_ref`] or [`CellImage::checked_to_ref`].
 #[derive(Clone, PartialEq, Eq)]
 pub struct CellImageRef<'buf, Layout = &'buf Bytes> {
-    inner: RawImage<&'buf cell_buf, Layout>,
+    pub(super) inner: RawImage<&'buf cell_buf, Layout>,
 }
 
 /// Image methods for all layouts.

--- a/texel/src/image/cell.rs
+++ b/texel/src/image/cell.rs
@@ -2,7 +2,7 @@
 //!
 //! Re-exported at its super `image` module.
 use crate::buf::{cell_buf, CellBuffer};
-use crate::image::{raw::RawImage, IntoPlanesError};
+use crate::image::{raw::RawImage, Image, IntoPlanesError};
 use crate::layout::{Bytes, Decay, Layout, Mend, PlaneOf, Relocate, SliceLayout, Take, TryMend};
 use crate::texel::{constants::U8, MAX_ALIGN};
 use crate::{BufferReuseError, Texel, TexelBuffer};
@@ -136,6 +136,38 @@ impl<L: Layout> CellImage<L> {
         Some(self.inner.checked_decay()?.into())
     }
 
+    /// Copy all bytes to a newly allocated image.
+    ///
+    /// Note this will allocate a buffer according to the capacity length of this reference, not
+    /// merely the layout. When this is not the intention, consider calling [`Self::split_layout`]
+    /// or [`Self::truncate_layout`] respectively.
+    ///
+    /// # Examples
+    ///
+    /// Here we make an independent copy of a pixel matrix image.
+    ///
+    /// ```
+    /// use image_texel::image::{CellImage, Image};
+    /// use image_texel::layout::{PlaneMatrices, Matrix};
+    /// use image_texel::texels::U8;
+    ///
+    /// let matrix = Matrix::from_width_height(U8, 8, 8).unwrap();
+    /// let buffer = CellImage::new(matrix);
+    ///
+    /// // … some code to initialize those planes.
+    /// # let mut buffer = buffer;
+    /// # let data = &buffer.as_cell_buf()[U8.to_range(0..8).unwrap()];
+    /// # U8.store_cell_slice(data, b"not zero");
+    /// # let buffer = buffer;
+    ///
+    /// let clone_of: Image<_> = buffer.clone().into_owned();
+    ///
+    /// assert!(clone_of.as_bytes() == buffer.as_cell_buf());
+    /// ```
+    pub fn into_owned(self) -> Image<L> {
+        self.inner.into_owned().into()
+    }
+
     /// Move the bytes into a new image.
     ///
     /// Afterwards, `self` will refer to an empty but unique new buffer.
@@ -189,6 +221,14 @@ impl<L> CellImage<L> {
     /// Check if two images refer to the same buffer.
     pub fn ptr_eq(&self, other: &Self) -> bool {
         CellBuffer::ptr_eq(self.inner.get(), other.inner.get())
+    }
+
+    /// Get a reference to the underlying buffer.
+    pub fn as_cell_buf(&self) -> &cell_buf
+    where
+        L: Layout,
+    {
+        self.inner.as_cell_buf()
     }
 
     /// Get a reference to the aligned unstructured bytes of the image.
@@ -421,6 +461,38 @@ impl<'data, L> CellImageRef<'data, L> {
         Some(self.inner.checked_decay()?.into())
     }
 
+    /// Copy all bytes to a newly allocated image.
+    ///
+    /// Note this will allocate a buffer according to the capacity length of this reference, not
+    /// merely the layout. When this is not the intention, consider calling [`Self::split_layout`]
+    /// or [`Self::truncate_layout`] respectively.
+    ///
+    /// # Examples
+    ///
+    /// Here we make an independent copy of a pixel matrix image.
+    ///
+    /// ```
+    /// use image_texel::image::{CellImage, Image};
+    /// use image_texel::layout::{PlaneMatrices, Matrix};
+    /// use image_texel::texels::U8;
+    ///
+    /// let matrix = Matrix::from_width_height(U8, 8, 8).unwrap();
+    /// let buffer = CellImage::new(PlaneMatrices::<_, 2>::from_repeated(matrix));
+    ///
+    /// // … some code to initialize those planes.
+    /// # let [plane] = buffer.as_ref().into_planes([1]).unwrap();
+    /// # let data = &plane.as_cell_buf()[U8.to_range(0..8).unwrap()];
+    /// # U8.store_cell_slice(data, b"not zero");
+    ///
+    /// let [plane1] = buffer.as_ref().into_planes([1]).unwrap();
+    /// let clone_of: Image<_> = plane1.clone().into_owned();
+    ///
+    /// assert!(clone_of.as_bytes() == plane1.as_cell_buf());
+    /// ```
+    pub fn into_owned(self) -> Image<L> {
+        self.inner.into_owned().into()
+    }
+
     /// Get a slice of the individual samples in the layout.
     pub fn as_slice(&self) -> &'_ Cell<[L::Sample]>
     where
@@ -528,6 +600,18 @@ impl<'data, L> CellImageRef<'data, L> {
         *buffer = initial;
 
         RawImage::from_buffer(Bytes(next.len()), next).into()
+    }
+
+    /// Remove all past-the-layout bytes.
+    ///
+    /// This is a utility to combine with pipelining. It is equivalent to calling
+    /// [`Self::split_layout`] and discarding that result.
+    pub fn truncate_layout(mut self) -> Self
+    where
+        L: Layout,
+    {
+        let _ = self.split_layout();
+        self
     }
 
     /// Split this reference into independent planes.

--- a/texel/src/image/cell.rs
+++ b/texel/src/image/cell.rs
@@ -139,8 +139,8 @@ impl<L: Layout> CellImage<L> {
     /// Copy all bytes to a newly allocated image.
     ///
     /// Note this will allocate a buffer according to the capacity length of this reference, not
-    /// merely the layout. When this is not the intention, consider calling [`Self::split_layout`]
-    /// or [`Self::truncate_layout`] respectively.
+    /// merely the layout. When this is not the intention, consider first adjusting the buffer by
+    /// reference with [`Self::as_ref`].
     ///
     /// # Examples
     ///

--- a/texel/src/texel.rs
+++ b/texel/src/texel.rs
@@ -1352,6 +1352,65 @@ impl<P> Texel<P> {
         lhs == rhs
     }
 
+    #[track_caller]
+    pub(crate) fn atomic_memory_move(self, a: AtomicSliceRef<'_, P>, b: AtomicSliceRef<'_, P>) {
+        struct SliceSource<'lt> {
+            skip: usize,
+            head: AtomicSliceRef<'lt, u8>,
+            // FIXME: the loads are straddling boundaries. Each side may be copied twice in the
+            // effort of loading. Also iterating like this incurs some bounds checks. It's very
+            // suboptimal. But the soundness of this whole thing scares me so let's not over
+            // optimize before we know atomic-to-atomic copy is actually needed to be very fast.
+            chunks: AtomicSliceRef<'lt, u8>,
+            tail: AtomicSliceRef<'lt, u8>,
+        }
+
+        impl DataSource for SliceSource<'_> {
+            fn init(&mut self, init: usize) {
+                let len = self.head.len().min(init);
+                let (head, body) = self.head.split_at(len);
+                self.head = head;
+                self.skip = MaxAtomic::PART_SIZE - init;
+
+                let chunks_len = body.len() & !(MaxAtomic::PART_SIZE - 1);
+                let (chunks, tail) = body.split_at(chunks_len);
+
+                self.chunks = chunks;
+                self.tail = tail;
+            }
+
+            fn load_head(&mut self, val: &mut [u8; MaxAtomic::PART_SIZE]) {
+                let target = &mut val[self.skip..][..self.head.len()];
+                constants::U8.load_atomic_slice(self.head, target);
+            }
+
+            fn load(&mut self, val: &mut [u8; MaxAtomic::PART_SIZE]) {
+                if let Some(next) = self.chunks.get(..MaxAtomic::PART_SIZE) {
+                    self.chunks = self.chunks.get(MaxAtomic::PART_SIZE..).unwrap();
+                    constants::U8.load_atomic_slice(next, val);
+                } else {
+                    debug_assert!(false);
+                }
+            }
+
+            fn load_tail(&mut self, val: &mut [u8; MaxAtomic::PART_SIZE]) {
+                let target = &mut val[..self.tail.len()];
+                constants::U8.load_atomic_slice(self.tail, target);
+            }
+        }
+
+        assert_eq!(a.len(), b.len());
+
+        let source = SliceSource {
+            head: self.atomic_bytes(a),
+            skip: 0,
+            chunks: atomic_buf::new(&[]).as_texels(constants::U8),
+            tail: atomic_buf::new(&[]).as_texels(constants::U8),
+        };
+
+        self.store_atomic_slice_unchecked(b, source);
+    }
+
     pub(crate) fn cast_buf<'buf>(self, buffer: &'buf buf) -> &'buf [P] {
         debug_assert_eq!(buffer.as_ptr() as usize % mem::align_of::<MaxAligned>(), 0);
         debug_assert_eq!(buffer.as_ptr() as usize % mem::align_of::<P>(), 0);

--- a/texel/src/texel.rs
+++ b/texel/src/texel.rs
@@ -692,6 +692,12 @@ trait DataSource {
 
 /// Operations that can be performed based on the evidence of Texel.
 impl<P> Texel<P> {
+    /// Construct a value of `P` from thin air, with zeroed representation.
+    pub fn zeroed(self) -> P {
+        // SAFETY: by `Texel` being a POD this is a valid representation.
+        unsafe { core::mem::zeroed::<P>() }
+    }
+
     /// Copy a texel.
     ///
     /// Note that this does not require `Copy` because that requirement was part of the
@@ -769,8 +775,7 @@ impl<P> Texel<P> {
     ///
     /// Each atomic unit is read at most once.
     pub fn load_atomic(self, val: AtomicRef<P>) -> P {
-        // SAFETY: by `Texel` being a POD this is a valid representation.
-        let mut value = unsafe { core::mem::zeroed::<P>() };
+        let mut value = self.zeroed();
         let slice = AtomicSliceRef::from_ref(val);
         let into = core::slice::from_ref(Cell::from_mut(&mut value));
         self.load_atomic_slice_unchecked(slice, into);


### PR DESCRIPTION
Adds a bunch of common utility method:

- The ability to transform any shared image into an owned one.
- Reading a reference to a texel buffer into a `Vec` and `TexelBuffer`.
- Adapters such that any`{Cell,Atomic,}Image{,Ref,Mut}` can be read and written with the transfers in the `data` module. That is, the unaligned buffers act merely as superset to the aligned images for the purpose of byte-by-byte access.
- The `Texel` can now memory move between two atomic slices.
- Expose `Texel::zeroed` for creating a texel value out of thin air as certified by `Pod`.
- `AtomicRef` can be stored to and loaded from directly, mimicking the `Cell` interface.