### PR TITLE
Image texel 0.5.0

### DIFF
--- a/canvas/src/layout.rs
+++ b/canvas/src/layout.rs
@@ -1,4 +1,5 @@
 //! Defines layout and buffer of our images.
+mod upsampling;
 
 use alloc::boxed::Box;
 

--- a/canvas/src/layout/upsampling.rs
+++ b/canvas/src/layout/upsampling.rs
@@ -1,4 +1,4 @@
-use crate::layout::TexelLayout;
+use image_texel::layout::TexelLayout;
 
 /// Planar chroma 2×2 block-wise sub-sampled image.
 ///
@@ -24,7 +24,7 @@ impl Yuv420p {
         let uv_count = y_count / 2;
 
         let count = y_count.checked_add(uv_count)?;
-        let _ = count.checked_mul(channel.size)?;
+        let _ = count.checked_mul(channel.size())?;
 
         Some(Yuv420p {
             channel,
@@ -34,7 +34,7 @@ impl Yuv420p {
     }
 
     pub const fn byte_len(self) -> usize {
-        let ylen = (self.width as usize) * (self.height as usize) * self.channel.size;
+        let ylen = (self.width as usize) * (self.height as usize) * self.channel.size();
         ylen + ylen / 2
     }
 }

--- a/texel/Changes.md
+++ b/texel/Changes.md
@@ -1,3 +1,39 @@
+# v0.5.0
+
+For the primitive buffers:
+- `cell_buf` can be indexed by a `TexelRange<P>` for `&Cell<P>`.
+- `cell_buf` can now be compared against `[u8]`.
+- `atomic_buf` can be indexed by a `TexelRange<P>` for `AtomicSliceRef<P>`.
+- `AtomicRef` gained `store` and `load`, mirroring methods on `Cell`.
+- `AtomicSliceRef<P>` can be efficiently loaded into an owned `Vec<P>` or an
+  aligned `TexelBuffer<P>`.
+
+For images:
+- `Decay` is now presumed to result in a layout that is at most the size of the
+  previous layout, as documented. The signature of functions no longer return
+  an `Option`, panicking instead on a violation. A new set of `checked_decay`
+  makes it consistently opt-in to verify this property.
+- `as_{capacity_,}{,cell_,atomic_}buf` are now consistently available on images
+  and their reference equivalents.
+- Shared and reference image types gained `into_owned` to convert them into an
+  owned `Image<L>` buffer with the same layout.
+- `CellImage` now exposes `as_cell_buf` and `as_capacity_cell_buf`.
+- `AtomicImage` now exposes `as_atomic_buf`
+
+The `image::data` module:
+- Added this module to interface between aligned image buffers and unaligned
+  external byte buffers. You can wrap `&[u8]`, `&mut [u8]` and `&[Cell<u8>]` to
+  transfer data between them.
+- Images have an `assign` method for transferring data _and_ layout. These are
+  fallible on all images other than `Image`, which can always reallocate its
+  buffers instead.
+- All images have `as_source` and `as_target` to treat them as unaligned slices
+  for the sake of interfaces specified as such. Copying relies on dynamic
+  dispatch, so these share the exact type of unaligned data buffers.
+
+Documentation:
+- received a major overhaul and a preface overview of the library.
+
 # v0.4.0
 
 - Add `AtomicImage`, `CellImage` and several supporting types and interfaces.

--- a/texel/src/image/raw.rs
+++ b/texel/src/image/raw.rs
@@ -1,7 +1,7 @@
 use core::ops;
 
 use crate::buf::{atomic_buf, buf, cell_buf, AtomicBuffer, Buffer, CellBuffer};
-use crate::layout::{Decay, DynLayout, Layout, SliceLayout, Take};
+use crate::layout::{Decay, Layout, SliceLayout, Take};
 use crate::{BufferReuseError, TexelBuffer};
 
 /// Inner buffer implementation.
@@ -118,24 +118,6 @@ impl<B: BufferLike, L> RawImage<B, L> {
         RawImage {
             buffer: BufferLike::into_owned(self.buffer),
             layout: self.layout,
-        }
-    }
-}
-
-/// Methods specifically with a dynamic layout.
-impl<B> RawImage<B, DynLayout> {
-    pub(crate) fn try_from_dynamic<Other>(self, layout: Other) -> Result<RawImage<B, Other>, Self>
-    where
-        Other: Into<DynLayout> + Clone,
-    {
-        let reference = layout.clone().into();
-        if self.layout == reference {
-            Ok(RawImage {
-                buffer: self.buffer,
-                layout,
-            })
-        } else {
-            Err(self)
         }
     }
 }


### PR DESCRIPTION

For the primitive buffers:
- `cell_buf` can be indexed by a `TexelRange<P>` for `&Cell<P>`.
- `cell_buf` can now be compared against `[u8]`.
- `atomic_buf` can be indexed by a `TexelRange<P>` for `AtomicSliceRef<P>`.
- `AtomicRef` gained `store` and `load`, mirroring methods on `Cell`.
- `AtomicSliceRef<P>` can be efficiently loaded into an owned `Vec<P>` or an
  aligned `TexelBuffer<P>`.

For images:
- `Decay` is now presumed to result in a layout that is at most the size of the
  previous layout, as documented. The signature of functions no longer return
  an `Option`, panicking instead on a violation. A new set of `checked_decay`
  makes it consistently opt-in to verify this property.
- `as_{capacity_,}{,cell_,atomic_}buf` are now consistently available on images
  and their reference equivalents.
- Shared and reference image types gained `into_owned` to convert them into an
  owned `Image<L>` buffer with the same layout.
- `CellImage` now exposes `as_cell_buf` and `as_capacity_cell_buf`.
- `AtomicImage` now exposes `as_atomic_buf`

The `image::data` module:
- Added this module to interface between aligned image buffers and unaligned
  external byte buffers. You can wrap `&[u8]`, `&mut [u8]` and `&[Cell<u8>]` to
  transfer data between them.
- Images have an `assign` method for transferring data _and_ layout. These are
  fallible on all images other than `Image`, which can always reallocate its
  buffers instead.
- All images have `as_source` and `as_target` to treat them as unaligned slices
  for the sake of interfaces specified as such. Copying relies on dynamic
  dispatch, so these share the exact type of unaligned data buffers.

Documentation:
- received a major overhaul and a preface overview of the library.