### PR TITLE
Provide constructors for ref images

### DIFF
--- a/texel/src/image/cell.rs
+++ b/texel/src/image/cell.rs
@@ -390,7 +390,66 @@ impl<L> CellImage<L> {
     */
 }
 
+impl<'data> CellImageRef<'data, Bytes> {
+    /// Wrap aligned data as a buffer for an image.
+    ///
+    /// # Examples
+    ///
+    /// You can create a buffer, then later transfer data and layout through [`data`].
+    ///
+    /// ```
+    /// use core::cell::Cell;
+    /// use image_texel::{image::CellImageRef, image::data, layout, texels};
+    ///
+    /// // Create our stack based image buffer.
+    /// let mut data = [texels::MAX.zeroed(); 16];
+    /// let cells = texels::cell_buf::from_max_mut(&mut data);
+    /// let image = CellImageRef::new(cells);
+    ///
+    /// # fn somewhere() -> data::DataRef<'static, layout::Matrix<u8>> {
+    /// #     let l = layout::Matrix::from_width_height(texels::U8, 4, 4).unwrap();
+    /// #     data::DataRef::with_layout_at(&[0; 16], l, 0).unwrap()
+    /// # }
+    /// // Now assume we have data from somewhere:
+    /// let data: data::DataRef<'_, layout::Matrix<u8>> = somewhere();
+    ///
+    /// let Some(image) = data.as_source().write_to_cell_ref(image) else {
+    ///     return; // Okay, our stack buffer was too small..
+    /// };
+    ///
+    /// // We now have a typed image buffer on the stack.
+    /// let image: CellImageRef<layout::Matrix<u8>> = image;
+    /// ```
+    pub fn new(data: &'data cell_buf) -> Self {
+        RawImage::from_buffer(Bytes(data.len()), data).into()
+    }
+}
+
 impl<'data, L> CellImageRef<'data, L> {
+    /// Wrap an aligned buffer, with a specified layout.
+    ///
+    /// # Examples
+    ///
+    /// You can create an image on the stack:
+    ///
+    /// ```
+    /// use image_texel::{image::CellImageRef, layout, texels};
+    ///
+    /// const LEN: usize = 256usize.div_ceil(texels::MAX.size());
+    /// let mut data = [texels::MAX.zeroed(); LEN];
+    /// let cells = texels::cell_buf::from_max_mut(&mut data);
+    ///
+    /// let layout = layout::Matrix::from_width_height(texels::U8, 16, 16).unwrap();
+    /// // Convert into an image buffer:
+    /// let image = CellImageRef::from_layout(cells, layout);
+    /// ```
+    pub fn from_layout(data: &'data cell_buf, layout: L) -> Self
+    where
+        L: Layout,
+    {
+        RawImage::from_buffer(layout, data).into()
+    }
+
     /// Get a reference to the underlying buffer.
     pub fn as_cell_buf(&self) -> &cell_buf
     where

--- a/texel/src/texel.rs
+++ b/texel/src/texel.rs
@@ -500,6 +500,15 @@ impl atomic_buf {
         }
     }
 
+    /// Wrap aligned bytes in an atomic buffer.
+    ///
+    /// This is similar to [`Self::from_bytes_mut`] but guaranteed to work. Values of the
+    /// `MaxAligned` type always fulfills the preconditions required by the call.
+    pub fn from_max_mut(bytes: &mut [MaxAligned]) -> &Self {
+        let bytes = constants::MAX.to_mut_bytes(bytes);
+        Self::from_bytes_mut(bytes).expect("this is surely aligned")
+    }
+
     /// Wrapper around the unstable `<Atomic*>::get_mut_slice`.
     pub(crate) fn part_mut_slice(slice: &mut [AtomicPart]) -> &mut [u8] {
         let len = core::mem::size_of_val(slice);
@@ -559,6 +568,16 @@ impl cell_buf {
     pub fn from_bytes_mut(bytes: &mut [u8]) -> Option<&Self> {
         let slice = Cell::from_mut(bytes).as_slice_of_cells();
         Self::from_bytes(slice)
+    }
+
+    /// Wrap aligned bytes in an unsynchronized shared `cell_buf`.
+    ///
+    /// This is similar to [`Self::from_bytes_mut`] but guaranteed to work. Values of the
+    /// `MaxAligned` type always fulfills the preconditions required by the call.
+    pub fn from_max_mut(bytes: &mut [MaxAligned]) -> &Self {
+        let bytes = constants::MAX.to_mut_bytes(bytes);
+        let slice = Cell::from_mut(bytes).as_slice_of_cells();
+        Self::from_bytes(slice).expect("this is surely aligned")
     }
 }
 


### PR DESCRIPTION
This complements the API for no-std users that do wish to allocate all their images. Instead, we can interact with them by reference only. This is a first step towards *maybe* providing a no-alloc version of this crate.