### PR TITLE
Lift shared canvas into image-canvas

### DIFF
--- a/canvas/benchmarks/bitpack.rs
+++ b/canvas/benchmarks/bitpack.rs
@@ -30,7 +30,7 @@ impl Convert {
         let mut into = Canvas::new(layout);
         into.set_color(self.color_out.clone())?;
 
-        Ok(move || from.convert(&mut into))
+        Ok(move || from.convert(&mut into).unwrap())
     }
 }
 

--- a/canvas/benchmarks/conversion.rs
+++ b/canvas/benchmarks/conversion.rs
@@ -7,7 +7,7 @@ use image_canvas::{
     Canvas, Converter,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Convert {
     texel_in: Texel,
     color_in: Color,
@@ -33,7 +33,28 @@ impl Convert {
         let mut into = Canvas::new(layout);
         into.set_color(self.color_out.clone())?;
 
-        Ok(move || from.convert(&mut into))
+        Ok(move || from.convert(&mut into).unwrap())
+    }
+
+    fn prepare_rc(&self) -> Result<impl FnMut(), LayoutError> {
+        let layout_from = CanvasLayout::with_texel(&self.texel_in, self.sz, self.sz)?;
+        let mut from = Canvas::new(layout_from.clone());
+        from.set_color(self.color_in.clone())?;
+
+        let layout_into = CanvasLayout::with_texel(&self.texel_out, self.sz, self.sz)?;
+        let mut into = Canvas::new(layout_into.clone());
+        into.set_color(self.color_out.clone())?;
+        let into = RcCanvas::from(into);
+
+        Ok(move || {
+            let mut converter = Converter::new();
+            let mut plan = converter
+                .plan(layout_from.clone(), layout_into.clone())
+                .unwrap();
+            plan.add_plane_in(from.plane(0).unwrap()).set_as_color();
+            plan.add_cell_out(into.plane(0).unwrap()).set_as_color();
+            plan.run().unwrap();
+        })
     }
 
     fn prepare_atomic(&self) -> Result<impl FnMut(), LayoutError> {
@@ -48,8 +69,12 @@ impl Convert {
 
         Ok(move || {
             let mut converter = Converter::new();
-            let mut plan = converter.plan(layout_from.clone(), layout_into.clone());
-            plan.add_plane_in(from.plane(0).unwrap());
+            let mut plan = converter
+                .plan(layout_from.clone(), layout_into.clone())
+                .unwrap();
+            plan.add_plane_in(from.plane(0).unwrap()).set_as_color();
+            plan.add_atomic_out(into.plane(0).unwrap()).set_as_color();
+            plan.run().unwrap();
         })
     }
 }
@@ -153,26 +178,26 @@ fn main() {
             color_out: Color::SRGB,
             sz: 128,
         },
-        /* conversion to oklab with different depths */
+        /* conversion from oklab with different depths */
         Convert {
-            texel_in: Texel::new_u8(SampleParts::Rgb),
-            color_in: Color::SRGB,
-            texel_out: Texel::new_u8(SampleParts::Lab),
-            color_out: Color::Oklab,
+            texel_in: Texel::new_u8(SampleParts::Lab),
+            color_in: Color::Oklab,
+            texel_out: Texel::new_u8(SampleParts::Rgb),
+            color_out: Color::SRGB,
             sz: 128,
         },
         Convert {
-            texel_in: Texel::new_u16(SampleParts::Rgb),
-            color_in: Color::SRGB,
-            texel_out: Texel::new_u16(SampleParts::Lab),
-            color_out: Color::Oklab,
+            texel_in: Texel::new_u16(SampleParts::Lab),
+            color_in: Color::Oklab,
+            texel_out: Texel::new_u16(SampleParts::Rgb),
+            color_out: Color::SRGB,
             sz: 128,
         },
         Convert {
-            texel_in: Texel::new_f32(SampleParts::Rgb),
-            color_in: Color::SRGB,
-            texel_out: Texel::new_f32(SampleParts::Lab),
-            color_out: Color::Oklab,
+            texel_in: Texel::new_f32(SampleParts::Lab),
+            color_in: Color::Oklab,
+            texel_out: Texel::new_f32(SampleParts::Rgb),
+            color_out: Color::SRGB,
             sz: 128,
         },
         /* conversion to SRLAB2 */
@@ -234,7 +259,8 @@ fn main() {
     ];
 
     let mut benches = brunch::Benches::default();
-    benches.extend(tests.map(|convert| {
+
+    benches.extend(tests.clone().map(|convert| {
         let bench = match convert.prepare() {
             Ok(bench) => bench,
             Err(err) => panic!("Failed to setup benchmark {:?}: {:?}", convert, err),
@@ -242,5 +268,24 @@ fn main() {
 
         Bench::new(format!("framebuf::conversion::main::{}", convert.name())).run(bench)
     }));
+
+    benches.extend(tests.clone().map(|convert| {
+        let bench = match convert.prepare_rc() {
+            Ok(bench) => bench,
+            Err(err) => panic!("Failed to setup benchmark {:?}: {:?}", convert, err),
+        };
+
+        Bench::new(format!("framebuf::conversion::rc::{}", convert.name())).run(bench)
+    }));
+
+    benches.extend(tests.clone().map(|convert| {
+        let bench = match convert.prepare_atomic() {
+            Ok(bench) => bench,
+            Err(err) => panic!("Failed to setup benchmark {:?}: {:?}", convert, err),
+        };
+
+        Bench::new(format!("framebuf::conversion::arc::{}", convert.name())).run(bench)
+    }));
+
     benches.finish();
 }

--- a/canvas/benchmarks/intcast.rs
+++ b/canvas/benchmarks/intcast.rs
@@ -28,7 +28,7 @@ impl Convert {
         let mut into = Canvas::new(layout);
         into.set_color(Color::SRGB)?;
 
-        Ok(move || from.convert(&mut into))
+        Ok(move || from.convert(&mut into).unwrap())
     }
 }
 

--- a/canvas/examples/convert-bgra.rs
+++ b/canvas/examples/convert-bgra.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), LayoutError> {
         }
     }
 
-    canvas.convert(&mut output);
+    canvas.convert(&mut output).unwrap();
 
     if std::env::var_os("IMAGE_CANVAS_SKIP_IO").is_none() {
         let container = output.as_texels(u8::texel()).to_owned();

--- a/canvas/examples/show-oklab.rs
+++ b/canvas/examples/show-oklab.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), LayoutError> {
         }
 
         // Simply convert.
-        canvas.convert(&mut output);
+        canvas.convert(&mut output).unwrap();
 
         // And copy the memory to a buffer that image expects. We could do something zero-copy here but
         // that's needlessly complicated to handle the size checks or encoding ourselves.

--- a/canvas/examples/show-srlab2.rs
+++ b/canvas/examples/show-srlab2.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), LayoutError> {
         }
 
         // Simply convert.
-        canvas.convert(&mut output);
+        canvas.convert(&mut output).unwrap();
 
         // And copy the memory to a buffer that image expects. We could do something zero-copy here but
         // that's needlessly complicated to handle the size checks or encoding ourselves.

--- a/canvas/src/bits.rs
+++ b/canvas/src/bits.rs
@@ -1,5 +1,4 @@
 use crate::layout::{SampleBits, SampleParts};
-use image_texel::AsTexel;
 use image_texel::Texel;
 
 /// Specifies which bits a channel comes from, within a `TexelKind` aggregate.

--- a/canvas/src/frame.rs
+++ b/canvas/src/frame.rs
@@ -3,17 +3,31 @@
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
-use image_texel::image::{ImageMut, ImageRef};
-use image_texel::Image;
+use image_texel::image::{
+    AtomicImage, AtomicImageRef, CellImage, CellImageRef, Image, ImageMut, ImageRef,
+};
+use image_texel::texels::U8;
 
 use crate::color::Color;
-use crate::layout::{CanvasLayout, ChannelLayout, LayoutError, PlanarLayout, PlaneBytes};
+use crate::layout::{CanvasLayout, ChannelLayout, LayoutError, PlanarLayout, PlaneBytes, PlaneIdx};
 use crate::shader::Converter;
 
 /// A byte buffer with dynamic color contents.
 #[derive(Clone)]
 pub struct Canvas {
     inner: Image<CanvasLayout>,
+}
+
+/// An image buffer that can be shared within a thread.
+#[derive(Clone)]
+pub struct RcCanvas {
+    inner: CellImage<CanvasLayout>,
+}
+
+/// An image buffer that can be shared across threads..
+#[derive(Clone)]
+pub struct ArcCanvas {
+    inner: AtomicImage<CanvasLayout>,
 }
 
 /// A byte buffer containing a single plane.
@@ -38,6 +52,20 @@ pub struct BytePlaneRef<'data> {
 /// Created from [`Canvas::plane_mut`].
 pub struct BytePlaneMut<'data> {
     inner: ImageMut<'data, PlaneBytes>,
+}
+
+/// Represents a single matrix like layer of a shared image.
+///
+/// Created from [`Canvas::plane_mut`].
+pub struct BytePlaneCells<'data> {
+    inner: CellImageRef<'data, PlaneBytes>,
+}
+
+/// Represents a single matrix like layer of a shared image.
+///
+/// Created from [`Canvas::plane_mut`].
+pub struct BytePlaneAtomics<'data> {
+    inner: AtomicImageRef<'data, PlaneBytes>,
 }
 
 /// Represents a single matrix like layer of an image.
@@ -328,6 +356,28 @@ impl Canvas {
     }
 }
 
+impl RcCanvas {
+    /// Get the untyped descriptor of a texel matrix.
+    ///
+    /// Returns `None` if the image contains data that can not be described as a single texel
+    /// plane, e.g. multiple planes or if the plane is not a matrix.
+    pub fn plane(&self, idx: u8) -> Option<BytePlaneCells<'_>> {
+        let [plane] = self.inner.as_ref().into_planes([PlaneIdx(idx)]).ok()?;
+        Some(BytePlaneCells { inner: plane })
+    }
+}
+
+impl ArcCanvas {
+    /// Get the untyped descriptor of a texel matrix.
+    ///
+    /// Returns `None` if the image contains data that can not be described as a single texel
+    /// plane, e.g. multiple planes or if the plane is not a matrix.
+    pub fn plane(&self, idx: u8) -> Option<BytePlaneAtomics<'_>> {
+        let [plane] = self.inner.as_ref().into_planes([PlaneIdx(idx)]).ok()?;
+        Some(BytePlaneAtomics { inner: plane })
+    }
+}
+
 impl<'data> BytePlaneRef<'data> {
     pub fn layout(&self) -> &PlaneBytes {
         self.inner.layout()
@@ -409,6 +459,38 @@ impl<'data> BytePlaneMut<'data> {
     }
 }
 
+impl<'data> BytePlaneCells<'data> {
+    pub fn layout(&self) -> &PlaneBytes {
+        self.inner.layout()
+    }
+
+    pub fn to_owned(&self) -> Plane {
+        Plane {
+            inner: self.inner.clone().into_owned(),
+        }
+    }
+
+    pub fn to_canvas(&self) -> Canvas {
+        self.to_owned().into()
+    }
+}
+
+impl<'data> BytePlaneAtomics<'data> {
+    pub fn layout(&self) -> &PlaneBytes {
+        self.inner.layout()
+    }
+
+    pub fn to_owned(&self) -> Plane {
+        Plane {
+            inner: self.inner.clone().into_owned(),
+        }
+    }
+
+    pub fn to_canvas(&self) -> Canvas {
+        self.to_owned().into()
+    }
+}
+
 impl<'data, C> ChannelsRef<'data, C> {
     pub fn layout(&self) -> &ChannelLayout<C> {
         self.inner.layout()
@@ -466,5 +548,66 @@ impl From<Plane> for Canvas {
         Canvas {
             inner: plane.inner.decay(),
         }
+    }
+}
+
+impl From<Canvas> for RcCanvas {
+    fn from(canvas: Canvas) -> Self {
+        RcCanvas {
+            inner: CellImage::with_bytes(canvas.layout().clone(), canvas.as_bytes()),
+        }
+    }
+}
+
+impl From<Canvas> for ArcCanvas {
+    fn from(canvas: Canvas) -> Self {
+        ArcCanvas {
+            inner: AtomicImage::with_bytes(canvas.layout().clone(), canvas.as_bytes()),
+        }
+    }
+}
+
+impl From<RcCanvas> for Canvas {
+    fn from(canvas: RcCanvas) -> Self {
+        Canvas {
+            inner: canvas.inner.into_owned(),
+        }
+    }
+}
+
+impl From<ArcCanvas> for Canvas {
+    fn from(canvas: ArcCanvas) -> Self {
+        Canvas {
+            inner: canvas.inner.into_owned(),
+        }
+    }
+}
+
+impl From<RcCanvas> for ArcCanvas {
+    fn from(canvas: RcCanvas) -> Self {
+        // Here we would want to allocate an Arc buffer straight from the Rc buffer. This is unsafe
+        // code has yet to be written and verified. Instead, we allocate a zeroed buffer under the
+        // assumption that this is conveniently fast, then copy data over.
+        let inner = canvas.inner;
+
+        let mut out = AtomicImage::new(inner.layout().clone());
+        let target = out.get_mut().expect("Still the sole owner");
+        U8.load_cell_slice(inner.as_texels(U8).as_slice_of_cells(), target.as_buf_mut());
+
+        ArcCanvas { inner: out }
+    }
+}
+
+impl From<ArcCanvas> for RcCanvas {
+    fn from(canvas: ArcCanvas) -> Self {
+        // Same choice as the inverse.
+        let inner = canvas.inner;
+
+        let out = CellImage::new(inner.layout().clone());
+        // That copy should be the same as filling mutable byte memory. Feel free to contradict
+        // this with benchmarks especially considering inlining.
+        U8.load_atomic_to_cells(inner.as_texels(U8), out.as_texels(U8).as_slice_of_cells());
+
+        RcCanvas { inner: out }
     }
 }

--- a/canvas/src/frame.rs
+++ b/canvas/src/frame.rs
@@ -352,7 +352,7 @@ impl Canvas {
 impl Canvas {
     /// Write into another frame, converting color representation between.
     pub fn convert(&self, into: &mut Self) {
-        Converter::new().run_on(self, into)
+        Converter::new().run_to_completion(self, into)
     }
 }
 

--- a/canvas/src/frame.rs
+++ b/canvas/src/frame.rs
@@ -367,6 +367,12 @@ impl Canvas {
 }
 
 impl RcCanvas {
+    pub fn new(layout: CanvasLayout) -> Self {
+        RcCanvas {
+            inner: CellImage::new(layout),
+        }
+    }
+
     /// Get the untyped descriptor of a texel matrix.
     ///
     /// Returns `None` if the image contains data that can not be described as a single texel
@@ -375,9 +381,21 @@ impl RcCanvas {
         let [plane] = self.inner.as_ref().into_planes([PlaneIdx(idx)]).ok()?;
         Some(BytePlaneCells { inner: plane })
     }
+
+    pub fn to_canvas(&self) -> Canvas {
+        Canvas {
+            inner: self.inner.clone().into_owned(),
+        }
+    }
 }
 
 impl ArcCanvas {
+    pub fn new(layout: CanvasLayout) -> Self {
+        ArcCanvas {
+            inner: AtomicImage::new(layout),
+        }
+    }
+
     /// Get the untyped descriptor of a texel matrix.
     ///
     /// Returns `None` if the image contains data that can not be described as a single texel
@@ -385,6 +403,12 @@ impl ArcCanvas {
     pub fn plane(&self, idx: u8) -> Option<BytePlaneAtomics<'_>> {
         let [plane] = self.inner.as_ref().into_planes([PlaneIdx(idx)]).ok()?;
         Some(BytePlaneAtomics { inner: plane })
+    }
+
+    pub fn to_canvas(&self) -> Canvas {
+        Canvas {
+            inner: self.inner.clone().into_owned(),
+        }
     }
 }
 

--- a/canvas/src/lib.rs
+++ b/canvas/src/lib.rs
@@ -80,7 +80,7 @@ mod tests;
 
 pub use self::frame::{Canvas, Plane};
 
-pub use self::shader::{Converter, ConverterRun, ConverterPlaneHandle};
+pub use self::shader::{Converter, ConverterPlaneHandle, ConverterRun};
 
 pub mod canvas {
     pub use crate::frame::{

--- a/canvas/src/lib.rs
+++ b/canvas/src/lib.rs
@@ -80,6 +80,8 @@ mod tests;
 
 pub use self::frame::{Canvas, Plane};
 
+pub use self::shader::{Converter, ConverterRun, ConverterPlaneHandle};
+
 pub mod canvas {
     pub use crate::frame::{
         ArcCanvas, BytePlaneAtomics, BytePlaneCells, BytePlaneMut, BytePlaneRef,

--- a/canvas/src/lib.rs
+++ b/canvas/src/lib.rs
@@ -82,8 +82,8 @@ pub use self::frame::{Canvas, Plane};
 
 pub mod canvas {
     pub use crate::frame::{
-        BytePlaneMut, BytePlaneRef, BytePlaneRef as BytePlane, ChannelsMut, ChannelsRef, PlaneMut,
-        PlaneRef,
+        ArcCanvas, BytePlaneAtomics, BytePlaneCells, BytePlaneMut, BytePlaneRef,
+        BytePlaneRef as BytePlane, ChannelsMut, ChannelsRef, PlaneMut, PlaneRef, RcCanvas,
     };
 }
 

--- a/canvas/src/tests.rs
+++ b/canvas/src/tests.rs
@@ -1,8 +1,11 @@
-use crate::color::Color;
-use crate::layout::{
-    Block, CanvasLayout, LayoutError, RowLayoutDescription, SampleBits, SampleParts, Texel,
+use crate::{
+    canvas::{ArcCanvas, RcCanvas},
+    color::Color,
+    layout::{
+        Block, CanvasLayout, LayoutError, RowLayoutDescription, SampleBits, SampleParts, Texel,
+    },
+    Canvas, Converter,
 };
-use crate::Canvas;
 
 #[test]
 fn simple_conversion() -> Result<(), LayoutError> {
@@ -559,4 +562,82 @@ fn a_bitpack_dilemma_unwrapped() {
 
         assert_eq!(&into.as_bytes()[3 * i..], IMG_BW_PACKED, "{i}");
     }
+}
+
+#[test]
+fn to_rc_conversion() -> Result<(), LayoutError> {
+    let texel = Texel::new_u8(SampleParts::RgbA);
+    let source_layout = CanvasLayout::with_texel(&texel, 32, 32)?;
+    let target_layout = CanvasLayout::with_texel(
+        &Texel {
+            bits: SampleBits::UInt565,
+            parts: SampleParts::Bgr,
+            ..texel
+        },
+        32,
+        32,
+    )?;
+
+    let mut from = Canvas::new(source_layout.clone());
+    let into = RcCanvas::new(target_layout.clone());
+
+    from.as_texels_mut(<[u8; 4] as image_texel::AsTexel>::texel())
+        .iter_mut()
+        .for_each(|b| *b = [0x7f, 0xff, 0x0, 0xff]);
+
+    // Expecting conversion [0xff, 0xff, 0x0, 0xff] to 0–ff—ff
+    {
+        let mut converter = Converter::new();
+        let mut plan = converter.plan(source_layout, target_layout).unwrap();
+        plan.add_plane_in(from.plane(0).unwrap()).set_as_color();
+        plan.add_cell_out(into.plane(0).unwrap()).set_as_color();
+        plan.run().unwrap();
+    }
+
+    let into = into.to_canvas();
+    into.as_texels(<[u8; 2] as image_texel::AsTexel>::texel())
+        .iter()
+        .enumerate()
+        .for_each(|(idx, b)| assert_eq!(u16::from_be_bytes(*b), 0x07ef, "at {}", idx));
+
+    Ok(())
+}
+
+#[test]
+fn to_arc_conversion() -> Result<(), LayoutError> {
+    let texel = Texel::new_u8(SampleParts::RgbA);
+    let source_layout = CanvasLayout::with_texel(&texel, 32, 32)?;
+    let target_layout = CanvasLayout::with_texel(
+        &Texel {
+            bits: SampleBits::UInt565,
+            parts: SampleParts::Bgr,
+            ..texel
+        },
+        32,
+        32,
+    )?;
+
+    let mut from = Canvas::new(source_layout.clone());
+    let into = ArcCanvas::new(target_layout.clone());
+
+    from.as_texels_mut(<[u8; 4] as image_texel::AsTexel>::texel())
+        .iter_mut()
+        .for_each(|b| *b = [0x7f, 0xff, 0x0, 0xff]);
+
+    // Expecting conversion [0xff, 0xff, 0x0, 0xff] to 0–ff—ff
+    {
+        let mut converter = Converter::new();
+        let mut plan = converter.plan(source_layout, target_layout).unwrap();
+        plan.add_plane_in(from.plane(0).unwrap()).set_as_color();
+        plan.add_atomic_out(into.plane(0).unwrap()).set_as_color();
+        plan.run().unwrap();
+    }
+
+    let into = into.to_canvas();
+    into.as_texels(<[u8; 2] as image_texel::AsTexel>::texel())
+        .iter()
+        .enumerate()
+        .for_each(|(idx, b)| assert_eq!(u16::from_be_bytes(*b), 0x07ef, "at {}", idx));
+
+    Ok(())
 }

--- a/canvas/src/tests.rs
+++ b/canvas/src/tests.rs
@@ -26,7 +26,7 @@ fn simple_conversion() -> Result<(), LayoutError> {
         .for_each(|b| *b = [0x7f, 0xff, 0x0, 0xff]);
 
     // Expecting conversion [0xff, 0xff, 0x0, 0xff] to 0–ff—ff
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     into.as_texels_mut(<[u8; 2] as image_texel::AsTexel>::texel())
         .iter()
@@ -72,7 +72,7 @@ fn color_no_conversion() -> Result<(), LayoutError> {
     let mut into = Canvas::new(layout);
     into.set_color(Color::SRGB)?;
 
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     into.as_texels(<[u8; 3] as image_texel::AsTexel>::texel())
         .iter()
@@ -101,15 +101,15 @@ fn color_conversion() -> Result<(), LayoutError> {
             .iter_mut()
             .for_each(|b| *b = rgb);
 
-        from.convert(&mut into);
+        from.convert(&mut into).unwrap();
 
         into.as_texels_mut(<[u8; 3] as image_texel::AsTexel>::texel())
             .iter()
             .enumerate()
             .for_each(|(idx, b)| assert_eq!(*b, lab, "at {}", idx));
 
-        from.convert(&mut rt);
-        rt.convert(&mut from);
+        from.convert(&mut rt).unwrap();
+        rt.convert(&mut from).unwrap();
 
         from.as_texels_mut(<[u8; 3] as image_texel::AsTexel>::texel())
             .iter()
@@ -150,7 +150,7 @@ fn non_rectantular() -> Result<(), LayoutError> {
         pixels.by_ref().take(32 * 32).for_each(|b| *b = rgb0);
         pixels.for_each(|b| *b = rgb1);
 
-        from.convert(&mut into);
+        from.convert(&mut into).unwrap();
 
         let mut pixels = into
             .as_texels_mut(<[u8; 3] as image_texel::AsTexel>::texel())
@@ -188,7 +188,7 @@ fn shuffled_samples() -> Result<(), LayoutError> {
         .iter_mut()
         .for_each(|b| *b = [0x40, 0x41, 0x42, 0x43]);
 
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     into.as_texels(<[u8; 4] as image_texel::AsTexel>::texel())
         .iter()
@@ -214,7 +214,7 @@ fn drop_shuffled_samples() -> Result<(), LayoutError> {
         .iter_mut()
         .for_each(|b| *b = [0x40, 0x41, 0x42, 0x43]);
 
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     into.as_texels(<[u8; 3] as image_texel::AsTexel>::texel())
         .iter()
@@ -240,7 +240,7 @@ fn expand_shuffled_samples() -> Result<(), LayoutError> {
         .iter_mut()
         .for_each(|b| *b = [0x40, 0x41, 0x42]);
 
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     into.as_texels(<[u8; 4] as image_texel::AsTexel>::texel())
         .iter()
@@ -294,7 +294,7 @@ fn expand_bits() -> Result<(), LayoutError> {
         .iter_mut()
         .for_each(|b| *b = [0x40, 0x41, 0x42]);
 
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     into.as_texels(<[u8; 4] as image_texel::AsTexel>::texel())
         .iter()
@@ -334,7 +334,7 @@ fn unpack_bits() -> Result<(), LayoutError> {
         .iter_mut()
         .for_each(|b| *b = 0x44);
 
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     into.as_texels(<[u8; 8] as image_texel::AsTexel>::texel())
         .iter()
@@ -381,7 +381,7 @@ fn pack_bits() -> Result<(), LayoutError> {
         .iter_mut()
         .for_each(|b| *b = [0x00, 0xff, 0xff, 0xff, 0x00, 0xff, 0x00, 0xff]);
 
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     into.as_texels(<u8 as image_texel::AsTexel>::texel())
         .iter()
@@ -410,15 +410,15 @@ fn yuv_conversion() -> Result<(), LayoutError> {
             .iter_mut()
             .for_each(|b| *b = rgb);
 
-        from.convert(&mut into);
+        from.convert(&mut into).unwrap();
 
         into.as_texels_mut(<[u8; 3] as image_texel::AsTexel>::texel())
             .iter()
             .enumerate()
             .for_each(|(idx, b)| assert_eq!(*b, yuv, "at {}", idx));
 
-        from.convert(&mut rt);
-        rt.convert(&mut from);
+        from.convert(&mut rt).unwrap();
+        rt.convert(&mut from).unwrap();
 
         from.as_texels_mut(<[u8; 3] as image_texel::AsTexel>::texel())
             .iter()
@@ -495,7 +495,7 @@ fn a_bitpack_dilemma_wrapped() {
     ];
 
     from.as_bytes_mut().copy_from_slice(IMG_BW_LUMA);
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     assert_eq!(into.as_bytes(), IMG_BW_PACKED);
 }
@@ -545,7 +545,7 @@ fn a_bitpack_dilemma_unwrapped() {
     ];
 
     from.as_bytes_mut().copy_from_slice(IMG_BW_LUMA);
-    from.convert(&mut into);
+    from.convert(&mut into).unwrap();
 
     assert_eq!(into.as_bytes(), IMG_BW_PACKED);
 
@@ -555,7 +555,7 @@ fn a_bitpack_dilemma_unwrapped() {
         let i = i as usize;
 
         from.as_bytes_mut()[24 * i..].copy_from_slice(IMG_BW_LUMA);
-        from.convert(&mut into);
+        from.convert(&mut into).unwrap();
 
         assert_eq!(&into.as_bytes()[3 * i..], IMG_BW_PACKED, "{i}");
     }


### PR DESCRIPTION
Most crucially this should allow to interact with the color conversion. This is complete when tests demonstrate the basic behavior, that is reading from a shared image that is in fact not modified at all through synchronization.

## Future extensions

- Have color conversion edit a sub-region of the whole planes or canvas layout. In and out regions need not be located at the same offsets (i.e. the whole canvases may have different widths and heights). Then tests should ensure that non-overlapping regions can be edited concurrently without affecting the conversion.
- Extend the provided interface of shared canvas for other modifications.