### PR TITLE
Allow bytes to be bound as input/output planes

### DIFF
--- a/canvas/src/frame.rs
+++ b/canvas/src/frame.rs
@@ -36,6 +36,22 @@ pub struct Plane {
     inner: Image<PlaneBytes>,
 }
 
+/// A reference to bytes containing data of a single plane.
+///
+/// This can be created from a [`Plane`] but also by validating an arbitrary slice of bytes against
+/// some of the known layouts. These layouts can be partially defined by the user.
+pub struct PlaneDataRef<'data> {
+    pub(crate) inner: ImageRef<'data, PlaneBytes>,
+}
+
+/// A reference to mutable bytes containing data of a single plane.
+///
+/// This can be created from a [`Plane`] but also by validating an arbitrary slice of bytes against
+/// some of the known layouts. These layouts can be partially defined by the user.
+pub struct PlaneDataMut<'data> {
+    pub(crate) inner: ImageMut<'data, PlaneBytes>,
+}
+
 /// Represents a single matrix like layer of an image.
 ///
 /// Created from [`Canvas::plane`].
@@ -643,5 +659,21 @@ impl From<ArcCanvas> for RcCanvas {
         U8.load_atomic_to_cells(inner.as_texels(U8), out.as_texels(U8).as_slice_of_cells());
 
         RcCanvas { inner: out }
+    }
+}
+
+impl<'lt> From<&'lt Plane> for PlaneDataRef<'lt> {
+    fn from(plane: &'_ Plane) -> PlaneDataRef<'_> {
+        PlaneDataRef {
+            inner: plane.inner.as_ref().into_cloned_layout(),
+        }
+    }
+}
+
+impl<'lt> From<&'lt mut Plane> for PlaneDataMut<'lt> {
+    fn from(plane: &'_ mut Plane) -> PlaneDataMut<'_> {
+        PlaneDataMut {
+            inner: plane.inner.as_mut().into_cloned_layout(),
+        }
     }
 }

--- a/canvas/src/layout.rs
+++ b/canvas/src/layout.rs
@@ -405,6 +405,7 @@ enum LayoutErrorInner {
     StrideError,
     NoChannelIndex(ColorChannel),
     ValidationError(u32),
+    LengthRequired { actual: usize, expected: usize },
 }
 
 impl Texel {
@@ -1228,6 +1229,15 @@ impl LayoutError {
     const NO_MODEL: Self = LayoutError {
         inner: LayoutErrorInner::NoModel,
     };
+
+    pub(crate) fn length_required(bytes: core::ops::Range<usize>) -> Self {
+        LayoutError {
+            inner: LayoutErrorInner::LengthRequired {
+                actual: bytes.start,
+                expected: bytes.end,
+            },
+        }
+    }
 
     fn validation(num: u32) -> Self {
         LayoutError {

--- a/canvas/src/lib.rs
+++ b/canvas/src/lib.rs
@@ -85,7 +85,8 @@ pub use self::shader::{ConversionError, Converter, ConverterPlaneHandle, Convert
 pub mod canvas {
     pub use crate::frame::{
         ArcCanvas, BytePlaneAtomics, BytePlaneCells, BytePlaneMut, BytePlaneRef,
-        BytePlaneRef as BytePlane, ChannelsMut, ChannelsRef, PlaneMut, PlaneRef, RcCanvas,
+        BytePlaneRef as BytePlane, ChannelsMut, ChannelsRef, PlaneDataMut, PlaneDataRef, PlaneMut,
+        PlaneRef, RcCanvas,
     };
 }
 

--- a/canvas/src/shader.rs
+++ b/canvas/src/shader.rs
@@ -4,7 +4,8 @@
 //! fragment unit, and pipeline multiple texels in parallel.
 use alloc::{boxed::Box, vec::Vec};
 use core::{fmt, ops::Range};
-use image_texel::image::{AtomicImageRef, CellImageRef, ImageMut, ImageRef};
+
+use image_texel::image::{AtomicImageRef, CellImageRef, DataMut, DataRef, ImageMut, ImageRef};
 use image_texel::{AsTexel, Texel, TexelBuffer};
 
 use crate::arch::ShuffleOps;
@@ -62,9 +63,11 @@ struct ConverterBuffer<'data> {
     in_plane: Vec<PlaneSource<'data>>,
     in_cell: Vec<CellSource<'data>>,
     in_atomic: Vec<AtomicSource<'data>>,
+    in_data: Vec<UnalignedSource<'data>>,
     out_plane: Vec<PlaneTarget<'data>>,
     out_cell: Vec<CellTarget<'data>>,
     out_atomic: Vec<AtomicTarget<'data>>,
+    out_data: Vec<UnalignedTarget<'data>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -72,6 +75,7 @@ enum PlaneIdx {
     Sync(u16),
     Cell(u16),
     Atomic(u16),
+    Data(u16),
 }
 
 /// An entry of data in a `ConverterRun`.
@@ -228,21 +232,25 @@ enum CommonPixelOrder {
 type PlaneSource<'data> = ImageRef<'data, PlaneBytes>;
 type CellSource<'data> = CellImageRef<'data, PlaneBytes>;
 type AtomicSource<'data> = AtomicImageRef<'data, PlaneBytes>;
+type UnalignedSource<'data> = DataRef<'data, PlaneBytes>;
 
 type PlaneTarget<'data> = ImageMut<'data, PlaneBytes>;
 type CellTarget<'data> = CellImageRef<'data, PlaneBytes>;
 type AtomicTarget<'data> = AtomicImageRef<'data, PlaneBytes>;
+type UnalignedTarget<'data> = DataMut<'data, PlaneBytes>;
 
 struct Sources<'re, 'data> {
     sync: &'re [PlaneSource<'data>],
     cell: &'re [CellSource<'data>],
     atomic: &'re [AtomicSource<'data>],
+    data: &'re [UnalignedSource<'data>],
 }
 
 struct Targets<'re, 'data> {
     sync: &'re mut [PlaneTarget<'data>],
     cell: &'re [CellTarget<'data>],
     atomic: &'re [AtomicTarget<'data>],
+    data: &'re mut [UnalignedTarget<'data>],
 }
 
 struct PlaneIo<'re, 'data> {
@@ -603,11 +611,13 @@ impl<'data> ConverterRun<'data> {
                 sync: &self.buffers.in_plane,
                 cell: &self.buffers.in_cell,
                 atomic: &self.buffers.in_atomic,
+                data: &self.buffers.in_data,
             },
             targets: Targets {
                 sync: &mut self.buffers.out_plane,
                 cell: &self.buffers.out_cell,
                 atomic: &self.buffers.out_atomic,
+                data: &mut self.buffers.out_data,
             },
         };
 
@@ -635,6 +645,12 @@ impl<'data> ConverterRun<'data> {
                 .get(usize::from(idx))
                 .ok_or(ConversionError::InputLayoutDoesNotMatchPlan)?
                 .layout(),
+            PlaneIdx::Data(idx) => self
+                .buffers
+                .in_data
+                .get(usize::from(idx))
+                .ok_or(ConversionError::InputLayoutDoesNotMatchPlan)?
+                .layout(),
         })
     }
 
@@ -655,6 +671,12 @@ impl<'data> ConverterRun<'data> {
             PlaneIdx::Atomic(idx) => self
                 .buffers
                 .out_atomic
+                .get(usize::from(idx))
+                .ok_or(ConversionError::OutputLayoutDoesNotMatchPlan)?
+                .layout(),
+            PlaneIdx::Data(idx) => self
+                .buffers
+                .out_data
                 .get(usize::from(idx))
                 .ok_or(ConversionError::OutputLayoutDoesNotMatchPlan)?
                 .layout(),
@@ -1193,6 +1215,25 @@ impl ConverterRt {
             }
         }
 
+        fn fetch_from_texel_unaligned<T>(
+            from: &UnalignedSource,
+            idx: &[usize],
+            into: &mut TexelBuffer,
+            range: Range<usize>,
+            texel: Texel<T>,
+        ) {
+            into.resize_for_texel(idx.len(), texel);
+            let idx = idx[range.clone()].iter();
+            let texels = &mut into.as_mut_texels(texel)[range];
+
+            let texel_slice = from.as_texels(texel);
+            for (&index, into) in idx.zip(texels) {
+                if let Some(from) = texel_slice.get(index) {
+                    *into = texel.unaligned().copy_val(from).0;
+                }
+            }
+        }
+
         struct ReadUnit<'plane, 'data> {
             from: &'plane PlaneSource<'data>,
             idx: &'plane [usize],
@@ -1229,6 +1270,19 @@ impl ConverterRt {
         impl GenericTexelAction for ReadAtomic<'_, '_> {
             fn run<T>(self, texel: Texel<T>) {
                 fetch_from_texel_atomics(self.from, self.idx, self.into, self.range, texel)
+            }
+        }
+
+        struct ReadData<'plane, 'data> {
+            from: &'plane UnalignedSource<'data>,
+            idx: &'plane [usize],
+            into: &'plane mut TexelBuffer,
+            range: Range<usize>,
+        }
+
+        impl GenericTexelAction for ReadData<'_, '_> {
+            fn run<T>(self, texel: Texel<T>) {
+                fetch_from_texel_unaligned(self.from, self.idx, self.into, self.range, texel)
             }
         }
 
@@ -1292,6 +1346,12 @@ impl ConverterRt {
                         range: 0..self.in_index_list.len(),
                     });
                 }
+                PlaneIdx::Data(_) => info.in_kind.action(ReadData {
+                    from: &from.sources.data[ops.color_in_plane.into_index()],
+                    idx: &self.in_index_list,
+                    into: &mut self.in_texels,
+                    range: 0..self.in_index_list.len(),
+                }),
             }
         }
     }
@@ -1369,6 +1429,29 @@ impl ConverterRt {
             }
         }
 
+        fn write_for_texel_data<T>(
+            into: &mut UnalignedTarget,
+            idx: &[usize],
+            from: &TexelBuffer,
+            range: Range<usize>,
+            texel: Texel<T>,
+        ) {
+            // FIXME(planar):
+            // FIXME(color): multi-planar texel write.
+            let idx = idx[range.clone()].iter();
+            let texels = &from.as_texels(texel)[range];
+            let texel_slice = into.as_texels_mut(texel);
+
+            // The index structure and used texel type should match.
+            debug_assert_eq!(idx.len(), texels.len());
+
+            for (&index, from) in idx.zip(texels) {
+                if let Some(into) = texel_slice.get_mut(index) {
+                    into.0 = texel.copy_val(from);
+                }
+            }
+        }
+
         struct WriteUnit<'plane, 'data> {
             into: &'plane mut PlaneTarget<'data>,
             idx: &'plane [usize],
@@ -1405,6 +1488,19 @@ impl ConverterRt {
         impl GenericTexelAction for WriteAtomic<'_, '_> {
             fn run<T>(self, texel: Texel<T>) {
                 write_for_texel_atomics(self.into, self.idx, self.from, self.range, texel)
+            }
+        }
+
+        struct WriteData<'plane, 'data> {
+            into: &'plane mut UnalignedTarget<'data>,
+            idx: &'plane [usize],
+            from: &'plane TexelBuffer,
+            range: Range<usize>,
+        }
+
+        impl GenericTexelAction for WriteData<'_, '_> {
+            fn run<T>(self, texel: Texel<T>) {
+                write_for_texel_data(self.into, self.idx, self.from, self.range, texel)
             }
         }
 
@@ -1467,6 +1563,12 @@ impl ConverterRt {
                         range: 0..self.out_index_list.len(),
                     });
                 }
+                PlaneIdx::Data(_) => info.out_kind.action(WriteData {
+                    into: &mut into.targets.data[ops.color_out_plane.into_index()],
+                    idx: &self.out_index_list,
+                    from: &self.out_texels,
+                    range: 0..self.out_index_list.len(),
+                }),
             }
         }
     }
@@ -1547,11 +1649,13 @@ impl<'re, 'data> PlaneIo<'re, 'data> {
                 sync: self.sources.sync,
                 cell: self.sources.cell,
                 atomic: self.sources.atomic,
+                data: self.sources.data,
             },
             targets: Targets {
                 sync: &mut *self.targets.sync,
                 cell: self.targets.cell,
                 atomic: self.targets.atomic,
+                data: &mut *self.targets.data,
             },
         }
     }
@@ -2362,6 +2466,7 @@ impl PlaneIdx {
             PlaneIdx::Sync(i) => i.into(),
             PlaneIdx::Cell(i) => i.into(),
             PlaneIdx::Atomic(i) => i.into(),
+            PlaneIdx::Data(i) => i.into(),
         }
     }
 }

--- a/texel/src/buf.rs
+++ b/texel/src/buf.rs
@@ -1566,8 +1566,13 @@ impl<T> TexelRange<T> {
         })
     }
 
+    /// Get a copy of the texel witness for this range.
+    pub fn texel(self) -> Texel<T> {
+        self.texel
+    }
+
     /// Intrinsically, all ranges represent an aligned range of bytes.
-    fn aligned_byte_range(self) -> ops::Range<usize> {
+    pub(crate) fn aligned_byte_range(self) -> ops::Range<usize> {
         let scale = self.texel.align();
         scale * self.start_per_align..scale * self.end_per_align
     }

--- a/texel/src/image.rs
+++ b/texel/src/image.rs
@@ -452,6 +452,26 @@ impl<L> Image<L> {
     }
 }
 
+impl<L> Image<&'_ L> {
+    /// Convert this image into one with an owned layout by cloning it.
+    pub fn into_cloned_layout(self) -> Image<L>
+    where
+        L: Layout + Clone,
+    {
+        self.inner.into_cloned_layout().into()
+    }
+}
+
+impl<L> Image<&'_ mut L> {
+    /// Convert this image into one with an owned layout by cloning it.
+    pub fn into_cloned_layout(self) -> Image<L>
+    where
+        L: Layout + Clone,
+    {
+        self.inner.into_cloned_layout().into()
+    }
+}
+
 /// Image methods for layouts based on pod samples.
 impl<L: SliceLayout> Image<L> {
     /// Interpret an existing buffer as a pixel image.
@@ -830,6 +850,26 @@ impl<'data, L> ImageRef<'data, L> {
 
         let planes = IntoPlanesError::from_array(planes)?;
         Ok(planes.map(|(layout, buffer)| RawImage::from_buffer(layout, buffer).into()))
+    }
+}
+
+impl<'data, L> ImageRef<'data, &'_ L> {
+    /// Convert this image into one with an owned layout by cloning it.
+    pub fn into_cloned_layout(self) -> ImageRef<'data, L>
+    where
+        L: Layout + Clone,
+    {
+        self.inner.into_cloned_layout().into()
+    }
+}
+
+impl<'data, L> ImageRef<'data, &'_ mut L> {
+    /// Convert this image into one with an owned layout by cloning it.
+    pub fn into_cloned_layout(self) -> ImageRef<'data, L>
+    where
+        L: Layout + Clone,
+    {
+        self.inner.into_cloned_layout().into()
     }
 }
 
@@ -1297,6 +1337,26 @@ impl<'data, L> ImageMut<'data, L> {
 
         let planes = IntoPlanesError::from_array(planes)?;
         Ok(planes.map(|(layout, buffer)| RawImage::from_buffer(layout, buffer).into()))
+    }
+}
+
+impl<'data, L> ImageMut<'data, &'_ L> {
+    /// Convert this image into one with an owned layout by cloning it.
+    pub fn into_cloned_layout(self) -> ImageMut<'data, L>
+    where
+        L: Layout + Clone,
+    {
+        self.inner.into_cloned_layout().into()
+    }
+}
+
+impl<'data, L> ImageMut<'data, &'_ mut L> {
+    /// Convert this image into one with an owned layout by cloning it.
+    pub fn into_cloned_layout(self) -> ImageMut<'data, L>
+    where
+        L: Layout + Clone,
+    {
+        self.inner.into_cloned_layout().into()
     }
 }
 

--- a/texel/src/image/data.rs
+++ b/texel/src/image/data.rs
@@ -128,11 +128,12 @@ mod sealed {
 use core::{cell::Cell, ops::Range};
 use sealed::{Loadable, Storable};
 
-use crate::buf::{atomic_buf, buf, cell_buf, AtomicBuffer, Buffer, CellBuffer};
+use crate::buf::{atomic_buf, buf, cell_buf, AtomicBuffer, Buffer, CellBuffer, TexelRange};
 use crate::image::{
     AtomicImage, AtomicImageRef, CellImage, CellImageRef, Image, ImageMut, ImageRef,
 };
 use crate::layout::{AlignedOffset, Bytes, Layout, Relocated};
+use crate::texel::Unaligned;
 use crate::{texels, BufferReuseError};
 
 /// A buffer with layout, not aligned to any particular boundary.
@@ -218,6 +219,25 @@ impl<'lt, L> DataRef<'lt, L> {
             })
     }
 
+    /// Get the underlying layout.
+    pub fn layout(&self) -> &L
+    where
+        L: Layout,
+    {
+        &self.layout
+    }
+
+    /// Interpret the wrapped data as a particular texel.
+    pub fn as_texels<T>(&self, texel: crate::Texel<T>) -> &[Unaligned<T>] {
+        texel.to_unaligned_slice(self.data)
+    }
+
+    /// Interpret a range of the wrapped data as a particular texel.
+    pub fn get_texels_at<T>(&self, range: TexelRange<T>) -> Option<&'_ [Unaligned<T>]> {
+        let data = self.data.get(range.aligned_byte_range())?;
+        Some(range.texel().to_unaligned_slice(data))
+    }
+
     /// An adapter reading from the data as one contiguous chunk.
     ///
     /// See [`RangeEngine`] for more explanations.
@@ -289,6 +309,36 @@ impl<'lt, L> DataMut<'lt, L> {
                 layout,
                 offset: start,
             })
+    }
+
+    /// Get the underlying layout.
+    pub fn layout(&self) -> &L
+    where
+        L: Layout,
+    {
+        &self.layout
+    }
+
+    /// Interpret the wrapped data as a particular texel.
+    pub fn as_texels<T>(&self, texel: crate::Texel<T>) -> &[Unaligned<T>] {
+        texel.to_unaligned_slice(self.data)
+    }
+
+    /// Interpret a range of the wrapped data as a particular texel.
+    pub fn get_texels_at<T>(&self, range: TexelRange<T>) -> Option<&'_ [Unaligned<T>]> {
+        let data = self.data.get(range.aligned_byte_range())?;
+        Some(range.texel().to_unaligned_slice(data))
+    }
+
+    /// Interpret the wrapped data as a particular texel.
+    pub fn as_texels_mut<T>(&mut self, texel: crate::Texel<T>) -> &mut [Unaligned<T>] {
+        texel.to_unaligned_slice_mut(self.data)
+    }
+
+    /// Interpret a range of the wrapped data as a particular texel.
+    pub fn get_texels_at_mut<T>(&mut self, range: TexelRange<T>) -> Option<&'_ mut [Unaligned<T>]> {
+        let data = self.data.get_mut(range.aligned_byte_range())?;
+        Some(range.texel().to_unaligned_slice_mut(data))
     }
 
     /// An adapter reading from the data as one contiguous chunk.
@@ -399,6 +449,14 @@ impl<'lt, L> DataCells<'lt, L> {
                 layout,
                 offset: Default::default(),
             })
+    }
+
+    /// Get the underlying layout.
+    pub fn layout(&self) -> &L
+    where
+        L: Layout,
+    {
+        &self.layout
     }
 
     /// An adapter reading from the data as one contiguous chunk.

--- a/texel/src/image/data.rs
+++ b/texel/src/image/data.rs
@@ -832,6 +832,23 @@ impl<L> ImageMut<'_, L> {
     }
 }
 
+impl<'data, L> ImageMut<'data, L> {
+    /// Interpret this reference to a mutable image as a view on a byte slice, discarding the
+    /// buffer's static alignment information.
+    pub fn into_data(self) -> DataMut<'data, L>
+    where
+        L: Layout,
+    {
+        let (data, layout) = self.inner.into_parts();
+
+        DataMut {
+            data,
+            layout,
+            offset: 0,
+        }
+    }
+}
+
 impl<L> ImageRef<'_, L> {
     /// An adapter reading from the data as one contiguous chunk.
     ///
@@ -843,6 +860,23 @@ impl<L> ImageRef<'_, L> {
         AsCopySource {
             inner: self.inner.get(),
             engine: RangeEngine::new(self.layout(), 0),
+        }
+    }
+}
+
+impl<'data, L> ImageRef<'data, L> {
+    /// Interpret this reference to an image as a view on a byte slice, discarding the buffer's
+    /// static alignment information.
+    pub fn into_data(self) -> DataRef<'data, L>
+    where
+        L: Layout,
+    {
+        let (data, layout) = self.inner.into_parts();
+
+        DataRef {
+            data,
+            layout,
+            offset: 0,
         }
     }
 }

--- a/texel/src/image/raw.rs
+++ b/texel/src/image/raw.rs
@@ -395,6 +395,38 @@ impl<B, L> RawImage<B, L> {
     }
 }
 
+impl<B, L> RawImage<B, &'_ L> {
+    /// Clone the layout from a reference.
+    ///
+    /// These layouts are always compatible as our impl for shared references simply forwards to
+    /// the underlying type's `Layout` implementation.
+    pub fn into_cloned_layout(self) -> RawImage<B, L>
+    where
+        L: Layout + Clone,
+    {
+        RawImage {
+            buffer: self.buffer,
+            layout: self.layout.clone(),
+        }
+    }
+}
+
+impl<B, L> RawImage<B, &'_ mut L> {
+    /// Clone the layout from a mutable reference.
+    ///
+    /// These layouts are always compatible as our impl for mutable references simply forwards to
+    /// the underlying type's `Layout` implementation.
+    pub fn into_cloned_layout(self) -> RawImage<B, L>
+    where
+        L: Layout + Clone,
+    {
+        RawImage {
+            buffer: self.buffer,
+            layout: self.layout.clone(),
+        }
+    }
+}
+
 /// Methods for all `Layouts` (the trait).
 impl<B: BufferLike, L: Layout> RawImage<B, L> {
     /// Get a mutable reference to those bytes used by the layout.


### PR DESCRIPTION
This adds a major interoperability item to `image-canvas`. You can now create a plane of referenced byte data (`PlaneDataRef`/`PlaneDataMut`) and bind these to the `ConverterRun` like you would bind any other plane. This allows you to read texel inputs and write texel outputs to _unaligned_ ranges of memory or otherwise memory that is controlled by the library. We thus complete a part of the promise of having all texels be Pod, that is we do not enforce invariant on the data part itself.